### PR TITLE
Don't return the root schema definition.

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -121,7 +121,7 @@ public final class SchemaTransformer {
         final SchemaPrinter.Options options = SchemaPrinter.Options.defaultOptions()
                 .includeScalarTypes(true)
                 .includeExtendedScalarTypes(true)
-                .includeSchemaDefintion(true)
+                .includeSchemaDefintion(false)
                 .includeDirectives(true);
         return new SchemaPrinter(options).print(originalSchema);
     }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/empty.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/empty.graphql
@@ -1,6 +1,2 @@
-schema {
-  query: Query
-}
-
 type Query {
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/product.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/product.graphql
@@ -1,7 +1,3 @@
-schema {
-  query: Query
-}
-
 type Money {
   amount: Int!
   currencyCode: String!


### PR DESCRIPTION
The federation spec appears to indicate that the root schema element should not be included in the printed SDL. This addresses #2.

