### PR TITLE
Add the _FieldSet type, make it the type for the input argument for @requires, @provides and @key

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import static graphql.Scalars.GraphQLString;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
 import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
@@ -29,11 +28,11 @@ import static graphql.schema.GraphQLDirective.newDirective;
 public final class FederationDirectives {
     private static final GraphQLArgument fieldsArgument = newArgument()
             .name("fields")
-            .type(new GraphQLNonNull(GraphQLString))
+            .type(new GraphQLNonNull(_FieldSet.type))
             .build();
     private static final InputValueDefinition fieldsDefinition = newInputValueDefinition()
             .name("fields")
-            .type(new NonNullType(new TypeName(GraphQLString.getName())))
+            .type(new NonNullType(new TypeName(_FieldSet.typeName)))
             .build();
 
     private static final DirectiveLocation DL_OBJECT = newDirectiveLocation()

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -86,6 +86,8 @@ public final class SchemaTransformer {
             final GraphQLUnionType entityType = _Entity.build(entityTypeNames);
 
             schema
+                    .additionalDirectives(FederationDirectives.allDirectives)
+                    .additionalType(_FieldSet.type)
                     .additionalType(entityType)
                     .additionalType(_Any.type);
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_FieldSet.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_FieldSet.java
@@ -1,0 +1,14 @@
+package com.apollographql.federation.graphqljava;
+
+import graphql.Scalars;
+import graphql.schema.GraphQLScalarType;
+
+final class _FieldSet {
+
+    static final String typeName = "_FieldSet";
+
+    static GraphQLScalarType type = GraphQLScalarType.newScalar(Scalars.GraphQLString)
+                    .name(typeName)
+                    .coercing(Scalars.GraphQLString.getCoercing())
+                    .build();
+}

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaUtils.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaUtils.java
@@ -19,9 +19,15 @@ final class SchemaUtils {
     private static final RuntimeWiring noop = RuntimeWiring.newRuntimeWiring().build();
 
     static GraphQLSchema buildSchema(String sdl) {
-        TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
-        typeRegistry.addAll(FederationDirectives.allDefinitions);
-        return new SchemaGenerator().makeExecutableSchema(typeRegistry, noop);
+        final TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
+        final SchemaGenerator.Options options = SchemaGenerator.Options
+                .defaultOptions()
+                .enforceSchemaDirectives(false);
+
+        return new SchemaGenerator().makeExecutableSchema(
+                options,
+                typeRegistry,
+                noop);
     }
 
     static String printSchema(GraphQLSchema schema) {


### PR DESCRIPTION
Here I've introduced the _FieldSet type and made it the type of the input argument for the @requires, @provides and @key directives. Addresses #5.

When adding the scalar type for _FieldSet to the type wiring, the _FieldSet scalar type is present in the original schema and is printed when generating the `sdl` field for the `_service` query (i.e. fetch service capabilities).

graphql-java's `SchemaPrinter` does not have the ability to exclude certain types from being printed. Since the schema returned by the _service query must exclude federation specific types and directives, we must find a way to exclude this type.

To do so I've taken the following approach:
1. Create the original schema without federation types. Note that in the `SchemaUtils` test helper I've removed the code to add definitions and moved it to the SchemaTransformer.
2. Create the original schema with the option to *not* enforce that directives are defined/correct.

If we want to enforce directives on initial schema creation, we can:
1. Implement our own SchemaPrinter :(
2. Lobby for modifications to SchemaPrinter to allow filtering of types or some other way to further customize the output.

My thought going forward is that we can create an abstraction for creating federated schemas that accepts `TypeDefinitionRegistry` and `TypeWiring` instances.

The combined approach has some advantages:
1. It simplifies federated schema creation for consumers. Consumers would just use `FederatedSchemaGenerator` instead of `SchemaGenerator`.
2. It is Spring Boot friendly. A starter can be created that consumes the `TypeDefinitionRegistry` and `TypeWiring` instances and creates a federated schema.
3. Schema creation logic is more encapsulated and can be changed/fixed. For example, if we would like to change the code to enforce the presence of directive definitions when creating schema, we can change this once we implement one of the alternative paths above.
