### PR TITLE
v0.1.0: valued directive creation, spec update, bugfix, CI fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,9 @@ jobs:
       - run:
           name: Test
           command: ./mvnw --settings settings.xml --batch-mode test
+
+workflows:
+  version: 2
+  Build and Test:
+    jobs:
+      - build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![MIT License](https://img.shields.io/github/license/apollographql/federation-jvm.svg)](LICENSE)
 [![Download](https://api.bintray.com/packages/apollographql/maven/federation-jvm/images/download.svg)](https://bintray.com/apollographql/maven/federation-jvm/_latestVersion)
-[![CircleCI](https://circleci.com/gh/apollographql/federation-jvm.svg?style=svg&circle-token=06a108f8cf15baf0a55228c9836cc25ee0aa5a50)](https://circleci.com/gh/apollographql/federation-jvm)
+[![CircleCI](https://circleci.com/gh/apollographql/federation-jvm.svg?style=svg)](https://circleci.com/gh/apollographql/federation-jvm)
 
 # Apollo Federation on the JVM
 
-Packages are available on [our bintray repository](https://bintray.com/apollographql/maven/federation-jvm).
+Packages published to [our bintray repository](https://bintray.com/apollographql/maven/federation-jvm)
+and available [in jcenter](https://jcenter.bintray.com/com/apollographql/federation/).

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.apollographql.federation</groupId>
         <artifactId>federation-parent</artifactId>
-        <version>${release}</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>federation-graphql-java-support</artifactId>

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull;
 
 public final class Federation {
     @NotNull
-    public static com.apollographql.federation.graphqljava.SchemaTransformer transform(final GraphQLSchema schema) {
+    public static SchemaTransformer transform(final GraphQLSchema schema) {
         return new SchemaTransformer(schema);
     }
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -26,82 +26,136 @@ import static graphql.schema.GraphQLDirective.newDirective;
 
 @PublicApi
 public final class FederationDirectives {
+    /* Directive locations */
+
+    private static final DirectiveLocation DL_OBJECT = newDirectiveLocation()
+            .name("OBJECT")
+            .build();
+
+    private static final DirectiveLocation DL_INTERFACE = newDirectiveLocation()
+            .name("INTERFACE")
+            .build();
+
+    private static final DirectiveLocation DL_FIELD_DEFINITION = newDirectiveLocation()
+            .name("FIELD_DEFINITION")
+            .build();
+
+    /* fields: _FieldSet */
+
     private static final GraphQLArgument fieldsArgument = newArgument()
             .name("fields")
             .type(new GraphQLNonNull(_FieldSet.type))
             .build();
+
+    private static final GraphQLArgument fieldsArgument(String value) {
+        return newArgument(fieldsArgument)
+                .value(value)
+                .build();
+    }
+
     private static final InputValueDefinition fieldsDefinition = newInputValueDefinition()
             .name("fields")
             .type(new NonNullType(new TypeName(_FieldSet.typeName)))
             .build();
 
-    private static final DirectiveLocation DL_OBJECT = newDirectiveLocation()
-            .name("OBJECT")
-            .build();
-    private static final DirectiveLocation DL_INTERFACE = newDirectiveLocation()
-            .name("INTERFACE")
-            .build();
-    private static final DirectiveLocation DL_FIELD_DEFINITION = newDirectiveLocation()
-            .name("FIELD_DEFINITION")
-            .build();
+    /* directive @key(fields: _FieldSet!) on OBJECT | INTERFACE */
 
     public static final String keyName = "key";
+
     public static final GraphQLDirective key = newDirective()
             .name(keyName)
             .validLocations(OBJECT, INTERFACE)
             .argument(fieldsArgument)
             .build();
+
+    public static final GraphQLDirective key(String fields) {
+        return newDirective(key)
+                .argument(fieldsArgument(fields))
+                .build();
+    }
+
     public static final DirectiveDefinition keyDefinition = newDirectiveDefinition()
             .name(keyName)
             .directiveLocations(Arrays.asList(DL_OBJECT, DL_INTERFACE))
             .inputValueDefinition(fieldsDefinition)
             .build();
 
+    /* directive @external on FIELD_DEFINITION */
+
     public static final String externalName = "external";
+
     public static final GraphQLDirective external = newDirective()
             .name(externalName)
             .validLocations(FIELD_DEFINITION)
             .build();
+
     public static final DirectiveDefinition externalDefinition = newDirectiveDefinition()
             .name(externalName)
             .directiveLocations(Arrays.asList(DL_FIELD_DEFINITION))
             .build();
 
+    /* directive @requires(fields: _FieldSet!) on FIELD_DEFINITION */
+
     public static final String requiresName = "requires";
+
     public static final GraphQLDirective requires = newDirective()
             .name(requiresName)
             .validLocations(FIELD_DEFINITION)
             .argument(fieldsArgument)
             .build();
+
+    public static final GraphQLDirective requires(String fields) {
+        return newDirective(requires)
+                .argument(fieldsArgument(fields))
+                .build();
+    }
+
     public static final DirectiveDefinition requiresDefinition = newDirectiveDefinition()
             .name(requiresName)
             .directiveLocations(Arrays.asList(DL_FIELD_DEFINITION))
             .inputValueDefinition(fieldsDefinition)
             .build();
 
+    /* directive @provides(fields: _FieldSet!) on FIELD_DEFINITION */
+
     public static final String providesName = "provides";
+
     public static final GraphQLDirective provides = newDirective()
             .name(providesName)
             .validLocations(FIELD_DEFINITION)
             .argument(fieldsArgument)
             .build();
+
+    public static final GraphQLDirective provides(String fields) {
+        return newDirective(provides)
+                .argument(fieldsArgument(fields))
+                .build();
+    }
+
     public static final DirectiveDefinition providesDefinition = newDirectiveDefinition()
             .name(providesName)
             .directiveLocations(Arrays.asList(DL_FIELD_DEFINITION))
             .inputValueDefinition(fieldsDefinition)
             .build();
 
+    /* directive @extends on OBJECT */
+
     public static final String extendsName = "extends";
+
     public static final GraphQLDirective extends_ = newDirective()
             .name(extendsName)
             .validLocations(OBJECT)
             .build();
+
     public static final DirectiveDefinition extendsDefinition = newDirectiveDefinition()
             .name(extendsName)
             .directiveLocations(Arrays.asList(DL_OBJECT))
             .build();
 
+    /* Sets */
+
     public static final Set<GraphQLDirective> allDirectives = new HashSet<>();
+
     public static final Set<SDLDefinition> allDefinitions = new HashSet<>();
 
     static {

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -60,11 +60,11 @@ public final class FederationDirectives {
     public static final String externalName = "external";
     public static final GraphQLDirective external = newDirective()
             .name(externalName)
-            .validLocations(OBJECT, FIELD_DEFINITION)
+            .validLocations(FIELD_DEFINITION)
             .build();
     public static final DirectiveDefinition externalDefinition = newDirectiveDefinition()
             .name(externalName)
-            .directiveLocations(Arrays.asList(DL_OBJECT, DL_FIELD_DEFINITION))
+            .directiveLocations(Arrays.asList(DL_FIELD_DEFINITION))
             .build();
 
     public static final String requiresName = "requires";

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -9,7 +9,6 @@ import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLUnionType;
 import graphql.schema.TypeResolver;
 import graphql.schema.idl.SchemaPrinter;
 import graphql.schema.idl.errors.SchemaProblem;
@@ -82,14 +81,9 @@ public final class SchemaTransformer {
                 .collect(Collectors.toSet());
 
         if (!entityTypeNames.isEmpty()) {
-            queryType.field(_Entity.field);
-            final GraphQLUnionType entityType = _Entity.build(entityTypeNames);
+            queryType.field(_Entity.field(entityTypeNames));
 
-            schema
-                    .additionalDirectives(FederationDirectives.allDirectives)
-                    .additionalType(_FieldSet.type)
-                    .additionalType(entityType)
-                    .additionalType(_Any.type);
+            schema.additionalDirectives(FederationDirectives.allDirectives);
 
             if (entityTypeResolver != null) {
                 codeRegistry.typeResolver(_Entity.typeName, entityTypeResolver);

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Any.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Any.java
@@ -21,8 +21,8 @@ import java.util.stream.Collectors;
 
 import static graphql.schema.GraphQLScalarType.newScalar;
 
-final class _Any {
-    static final String typeName = "_Any";
+public final class _Any {
+    public static final String typeName = "_Any";
 
     static GraphQLScalarType type = newScalar()
             .name(typeName)

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
@@ -12,10 +12,10 @@ import java.util.Set;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 
-final class _Entity {
+public final class _Entity {
     static final String typeName = "_Entity";
     static final String fieldName = "_entities";
-    static final String argumentName = "representations";
+    public static final String argumentName = "representations";
 
     // graphql-java will mutate GraphQLTypeReference in-place,
     // so we need to create a new instance every time.

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
@@ -17,22 +17,26 @@ final class _Entity {
     static final String fieldName = "_entities";
     static final String argumentName = "representations";
 
-    static GraphQLFieldDefinition field = newFieldDefinition()
-            .name(fieldName)
-            .argument(newArgument()
-                    .name(argumentName)
-                    .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(_Any.type))))
-                    .build())
-            .type(new GraphQLNonNull(new GraphQLList(new GraphQLTypeReference(typeName))))
-            .build();
-
-    static GraphQLUnionType build(@NotNull Set<String> typeNames) {
-        final GraphQLTypeReference[] references = typeNames.stream()
-                .map(GraphQLTypeReference::new)
-                .toArray(GraphQLTypeReference[]::new);
-        return GraphQLUnionType.newUnionType()
-                .name(typeName)
-                .possibleTypes(references)
+    // graphql-java will mutate GraphQLTypeReference in-place,
+    // so we need to create a new instance every time.
+    static GraphQLFieldDefinition field(@NotNull Set<String> typeNames) {
+        return newFieldDefinition()
+                .name(fieldName)
+                .argument(newArgument()
+                        .name(argumentName)
+                        .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(_Any.type))))
+                        .build())
+                .type(new GraphQLNonNull(
+                                new GraphQLList(
+                                        GraphQLUnionType.newUnionType()
+                                                .name(typeName)
+                                                .possibleTypes(typeNames.stream()
+                                                        .map(GraphQLTypeReference::new)
+                                                        .toArray(GraphQLTypeReference[]::new))
+                                                .build()
+                                )
+                        )
+                )
                 .build();
     }
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_FieldSet.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_FieldSet.java
@@ -4,11 +4,10 @@ import graphql.Scalars;
 import graphql.schema.GraphQLScalarType;
 
 final class _FieldSet {
-
     static final String typeName = "_FieldSet";
 
     static GraphQLScalarType type = GraphQLScalarType.newScalar(Scalars.GraphQLString)
-                    .name(typeName)
-                    .coercing(Scalars.GraphQLString.getCoercing())
-                    .build();
+            .name(typeName)
+            .coercing(Scalars.GraphQLString.getCoercing())
+            .build();
 }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -59,7 +59,7 @@ class FederationTest {
         final GraphQLSchema schema = SchemaUtils.buildSchema(sdl);
 
         final GraphQLSchema federated = Federation.transform(schema)
-                .fetchEntities((DataFetcher) env ->
+                .fetchEntities(env ->
                         env.<List<Map<String, Object>>>getArgument(_Entity.argumentName)
                                 .stream()
                                 .map(map -> {
@@ -84,5 +84,19 @@ class FederationTest {
         final List<Map<String, Object>> _entities = (List<Map<String, Object>>) data.get("_entities");
         assertEquals(1, _entities.size());
         assertEquals(180, _entities.get(0).get("price"));
+    }
+
+    // From https://github.com/apollographql/federation-jvm/issues/7
+    @Test
+    void testSchemaTransformationIsolated() {
+        final String sdl = TestUtils.readResource("isolated.graphql");
+        Federation.transform(SchemaUtils.buildSchema(sdl))
+                .resolveEntityType(env -> null)
+                .fetchEntities(environment -> null)
+                .build();
+        Federation.transform(SchemaUtils.buildSchema(sdl))
+                .resolveEntityType(env -> null)
+                .fetchEntities(environment -> null)
+                .build();
     }
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/isolated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/isolated.graphql
@@ -1,0 +1,8 @@
+type Query {
+}
+
+type SomeType @key(fields: "theKey") {
+    theKey: ID!
+    field1: String!
+    field2: Int!
+}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.apollographql.federation</groupId>
     <artifactId>federation-parent</artifactId>
     <name>federation-parent</name>
-    <version>${release}</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/apollographql/federation-jvm</url>
@@ -45,7 +45,7 @@
     </scm>
 
     <properties>
-        <release>0.0.3</release>
+        <release>0.1.0</release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -59,7 +59,6 @@
         <lombok-maven-plugin.version>1.18.6.0</lombok-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
@@ -156,15 +155,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>${maven-release-plugin.version}</version>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <tagNameFormat>v@{project.version}</tagNameFormat>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.apollographql.federation</groupId>
         <artifactId>federation-parent</artifactId>
-        <version>${release}</version>
+        <version>0.1.0</version>
     </parent>
 
     <artifactId>federation-spring-example</artifactId>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.apollographql.federation</groupId>
             <artifactId>federation-graphql-java-support</artifactId>
-            <version>${release}</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- Make some names public, when likely to be accessed
- Make it easy to construct directives with values
- `@external` isn't allowed on `OBJECT`
- Fix a bug around building multiple schemas (`_Entity.field` was mutated during schema builds to resolve type references)
- Fix `pom.xml` files for bintray uploads
- Drop release plugin configuration

Please see individual commits for details.