### PR TITLE
Start 0.2.0-SNAPSHOT with minor changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: azul/zulu-openjdk:8
+      - image: circleci/openjdk:8
     steps:
       - checkout
       - run:
@@ -19,11 +19,16 @@ jobs:
             - ~/.m2
           key: cache-{{ checksum "allpoms.xml" }}
       - run:
-          name: Build & install
-          command: ./mvnw --settings settings.xml --batch-mode install
+          name: Build, install, test
+          command: ./mvnw --settings settings.xml --batch-mode install test
       - run:
-          name: Test
-          command: ./mvnw --settings settings.xml --batch-mode test
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
 
 workflows:
   version: 2

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.apollographql.federation</groupId>
         <artifactId>federation-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>federation-graphql-java-support</artifactId>

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -44,6 +44,10 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
             </plugin>
             <plugin>

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -4,11 +4,11 @@ import graphql.schema.GraphQLSchema;
 import org.jetbrains.annotations.NotNull;
 
 public final class Federation {
+    private Federation() {
+    }
+
     @NotNull
     public static SchemaTransformer transform(final GraphQLSchema schema) {
         return new SchemaTransformer(schema);
-    }
-
-    private Federation() {
     }
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationError.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationError.java
@@ -13,6 +13,10 @@ public class FederationError extends GraphQLException implements GraphQLError {
     private static final List<SourceLocation> NO_WHERE =
             Collections.singletonList(new SourceLocation(-1, -1));
 
+    FederationError(String message) {
+        super(message);
+    }
+
     @Override
     public List<SourceLocation> getLocations() {
         return NO_WHERE;
@@ -21,9 +25,5 @@ public class FederationError extends GraphQLException implements GraphQLError {
     @Override
     public ErrorClassification getErrorType() {
         return ErrorType.ValidationError;
-    }
-
-    FederationError(String message) {
-        super(message);
     }
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
@@ -13,9 +13,12 @@ import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 
 public final class _Entity {
+    public static final String argumentName = "representations";
     static final String typeName = "_Entity";
     static final String fieldName = "_entities";
-    public static final String argumentName = "representations";
+
+    private _Entity() {
+    }
 
     // graphql-java will mutate GraphQLTypeReference in-place,
     // so we need to create a new instance every time.
@@ -38,8 +41,5 @@ public final class _Entity {
                         )
                 )
                 .build();
-    }
-
-    private _Entity() {
     }
 }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaUtils.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaUtils.java
@@ -18,6 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 final class SchemaUtils {
     private static final RuntimeWiring noop = RuntimeWiring.newRuntimeWiring().build();
 
+    private SchemaUtils() {
+    }
+
     static GraphQLSchema buildSchema(String sdl) {
         final TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
         final SchemaGenerator.Options options = SchemaGenerator.Options
@@ -47,8 +50,5 @@ final class SchemaUtils {
         assertNotNull(_service);
         final String sdl = (String) _service.get("sdl");
         assertEquals(expected.trim(), sdl.trim());
-    }
-
-    private SchemaUtils() {
     }
 }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/TestUtils.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/TestUtils.java
@@ -6,13 +6,13 @@ import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
 final class TestUtils {
+    private TestUtils() {
+    }
+
     static String readResource(String name) {
         InputStream is = SchemaUtils.class.getResourceAsStream(name);
         assert is != null;
         BufferedReader reader = new BufferedReader(new InputStreamReader(is));
         return reader.lines().collect(Collectors.joining(System.lineSeparator()));
-    }
-
-    private TestUtils() {
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
-        <spring-boot.version>2.1.5.RELEASE</spring-boot.version>
+        <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <lombok-maven-plugin.version>1.18.6.0</lombok-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
@@ -155,6 +156,22 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <notimestamp>true</notimestamp>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.apollographql.federation</groupId>
     <artifactId>federation-parent</artifactId>
     <name>federation-parent</name>
-    <version>0.1.0</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/apollographql/federation-jvm</url>
@@ -45,13 +45,13 @@
     </scm>
 
     <properties>
-        <release>0.1.0</release>
+        <release>0.2.0-SNAPSHOT</release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <graphql-java.version>12.0</graphql-java.version>
-        <graphql-spring-boot.version>5.9.0</graphql-spring-boot.version>
+        <graphql-java.version>13.0</graphql-java.version>
+        <graphql-spring-boot.version>5.10.0</graphql-spring-boot.version>
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
         <junit.version>5.4.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <!-- Workaround from https://stackoverflow.com/questions/50661648/spring-boot-fails-to-run-maven-surefire-plugin-classnotfoundexception-org-apache/50661649#50661649 -->
+                        <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.projectlombok</groupId>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.apollographql.federation</groupId>
         <artifactId>federation-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>federation-spring-example</artifactId>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.apollographql.federation</groupId>
             <artifactId>federation-graphql-java-support</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- Start using 0.2.0-SNAPSHOT as our version
- Update spring-boot
- Move CI to using openjdk, integrate with Maven test reports
- Maven javadoc plugin configuration