### PR TITLE
graphql-java-support: include federation directive definitions in SDL

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -12,7 +12,7 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLNonNull;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
@@ -158,19 +158,19 @@ public final class FederationDirectives {
 
     /* Sets */
 
-    public static final Set<GraphQLDirective> allDirectives = new HashSet<>();
-    public static final Set<SDLDefinition> allDefinitions = new HashSet<>();
+    public static final Set<GraphQLDirective> allDirectives = new LinkedHashSet<>();
+    public static final Set<SDLDefinition> allDefinitions = new LinkedHashSet<>();
 
     static {
-        allDirectives.add(key);
-        allDirectives.add(external);
-        allDirectives.add(requires);
-        allDirectives.add(provides);
         allDirectives.add(extends_);
-        allDefinitions.add(keyDefinition);
-        allDefinitions.add(externalDefinition);
-        allDefinitions.add(requiresDefinition);
-        allDefinitions.add(providesDefinition);
+        allDirectives.add(external);
+        allDirectives.add(key);
+        allDirectives.add(provides);
+        allDirectives.add(requires);
         allDefinitions.add(extendsDefinition);
+        allDefinitions.add(externalDefinition);
+        allDefinitions.add(keyDefinition);
+        allDefinitions.add(providesDefinition);
+        allDefinitions.add(requiresDefinition);
     }
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_FieldSet.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_FieldSet.java
@@ -10,6 +10,7 @@ public final class _FieldSet {
     public static GraphQLScalarType type = GraphQLScalarType.newScalar(Scalars.GraphQLString)
             .name(typeName)
             .coercing(Scalars.GraphQLString.getCoercing())
+            .description(null)
             .build();
 
     public static final ScalarTypeDefinition definition = ScalarTypeDefinition.newScalarTypeDefinition()

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -22,15 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FederationTest {
-    private final String emptySDL = TestUtils.readResource("schemas/empty.graphql");
-    private final String interfacesSDL = TestUtils.readResource("schemas/interfaces.graphql");
-    private final String isolatedSDL = TestUtils.readResource("schemas/isolated.graphql");
     private final String productSDL = TestUtils.readResource("schemas/product.graphql");
 
     @Test
     void testEmpty() {
-        final GraphQLSchema federated = Federation.transform(emptySDL)
-                .build();
+        final GraphQLSchema federated = Federation.transform(TestUtils.readResource("schemas/empty.graphql")).build();
         Assertions.assertEquals("type Query {\n" +
                 "  _service: _Service\n" +
                 "}\n" +
@@ -45,7 +41,8 @@ class FederationTest {
         assertNotNull(_service, "_service field present");
         assertEquals(_Service, _service.getType(), "_service returns _Service");
 
-        SchemaUtils.assertSDL(federated, emptySDL);
+        SchemaUtils.assertSDL(federated,
+                TestUtils.readResource("schemas/empty.federated.graphql"));
     }
 
     @Test
@@ -74,7 +71,7 @@ class FederationTest {
                 .resolveEntityType(env -> env.getSchema().getObjectType("Product"))
                 .build();
 
-        SchemaUtils.assertSDL(federated, productSDL);
+        SchemaUtils.assertSDL(federated, TestUtils.readResource("schemas/product.federated.graphql"));
 
         final ExecutionResult result = SchemaUtils.execute(federated, "{\n" +
                 "  _entities(representations: [{__typename:\"Product\"}]) {\n" +
@@ -93,11 +90,12 @@ class FederationTest {
     // From https://github.com/apollographql/federation-jvm/issues/7
     @Test
     void testSchemaTransformationIsolated() {
-        Federation.transform(isolatedSDL)
+        final String sdl = TestUtils.readResource("schemas/isolated.graphql");
+        Federation.transform(sdl)
                 .resolveEntityType(env -> null)
                 .fetchEntities(environment -> null)
                 .build();
-        Federation.transform(isolatedSDL)
+        Federation.transform(sdl)
                 .resolveEntityType(env -> null)
                 .fetchEntities(environment -> null)
                 .build();
@@ -111,7 +109,7 @@ class FederationTest {
                         .build())
                 .build();
 
-        final GraphQLSchema transformed = Federation.transform(interfacesSDL, wiring)
+        final GraphQLSchema transformed = Federation.transform(TestUtils.readResource("schemas/interfaces.graphql"), wiring)
                 .resolveEntityType(env -> null)
                 .fetchEntities(environment -> null)
                 .build();

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.federated.graphql
@@ -1,0 +1,19 @@
+schema {
+  query: Query
+}
+
+directive @extends on OBJECT
+
+directive @external on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+type Query {
+}
+
+#Built-in String
+scalar _FieldSet

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.federated.graphql
@@ -15,5 +15,4 @@ directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
 type Query {
 }
 
-#Built-in String
 scalar _FieldSet

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.graphql
@@ -1,5 +1,5 @@
 schema {
-  query: Query
+    query: Query
 }
 
 type Query {

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/isolated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/isolated.graphql
@@ -1,6 +1,3 @@
-type Query {
-}
-
 type SomeType @key(fields: "theKey") {
     theKey: ID!
     field1: String!

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.federated.graphql
@@ -1,0 +1,31 @@
+schema {
+  query: Query
+}
+
+directive @extends on OBJECT
+
+directive @external on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+type Money {
+  amount: Int!
+  currencyCode: String!
+}
+
+type Product @key(fields : "upc") {
+  name: String
+  price: Int
+  sku: String!
+  upc: String!
+}
+
+type Query {
+}
+
+#Built-in String
+scalar _FieldSet

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.federated.graphql
@@ -27,5 +27,4 @@ type Product @key(fields : "upc") {
 type Query {
 }
 
-#Built-in String
 scalar _FieldSet

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
@@ -1,7 +1,3 @@
-schema {
-  query: Query
-}
-
 type Money {
   amount: Int!
   currencyCode: String!
@@ -12,7 +8,4 @@ type Product @key(fields : "upc") {
   price: Int
   sku: String!
   upc: String!
-}
-
-type Query {
 }


### PR DESCRIPTION
@zionts suggested the directives should be included in `{_service{sdl}}`.