### PR TITLE
spring-example pom.xml: assembly plugin

### DIFF
--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -75,6 +75,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
             </plugin>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -53,6 +53,29 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>
+                                        com.apollographql.federation.springexample.App
+                                    </mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
             </plugin>
             <plugin>


### PR DESCRIPTION
Allows for:

```
$ mvn package && java -jar spring-example/target/federation-spring-example-0.2.1-SNAPSHOT-jar-with-dependencies.jar
```

We should confirm the artifacts do not get attached for upload.

Should update README.md to reflect the option.