### PR TITLE
Null check on throwable.message

### DIFF
--- a/.idea/federation-jvm.iml
+++ b/.idea/federation-jvm.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/federation-jvm.iml
+++ b/.idea/federation-jvm.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -176,6 +176,8 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
                     }
 
                     graphQLErrors.add(errorBuilder.build());
+                } else {
+                    logger.debug(throwable.toString());
                 }
             }
         }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -166,14 +166,17 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
             if (throwable instanceof GraphQLError) {
                 graphQLErrors.add((GraphQLError) throwable);
             } else {
-                GraphqlErrorBuilder errorBuilder = GraphqlErrorBuilder.newError()
-                        .message(throwable.getMessage());
+                String message = throwable.getMessage();
+                if (message != null) {
+                    GraphqlErrorBuilder errorBuilder = GraphqlErrorBuilder.newError()
+                            .message(message);
 
-                if (throwable instanceof InvalidSyntaxException) {
-                    errorBuilder.location(((InvalidSyntaxException) throwable).getLocation());
+                    if (throwable instanceof InvalidSyntaxException) {
+                        errorBuilder.location(((InvalidSyntaxException) throwable).getLocation());
+                    }
+
+                    graphQLErrors.add(errorBuilder.build());
                 }
-
-                graphQLErrors.add(errorBuilder.build());
             }
         }
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -167,18 +167,17 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
                 graphQLErrors.add((GraphQLError) throwable);
             } else {
                 String message = throwable.getMessage();
-                if (message != null) {
-                    GraphqlErrorBuilder errorBuilder = GraphqlErrorBuilder.newError()
-                            .message(message);
-
-                    if (throwable instanceof InvalidSyntaxException) {
-                        errorBuilder.location(((InvalidSyntaxException) throwable).getLocation());
-                    }
-
-                    graphQLErrors.add(errorBuilder.build());
-                } else {
-                    logger.debug(throwable.toString());
+                if (message == null) {
+                    message = "(null)";
                 }
+                GraphqlErrorBuilder errorBuilder = GraphqlErrorBuilder.newError()
+                        .message(message);
+
+                if (throwable instanceof InvalidSyntaxException) {
+                    errorBuilder.location(((InvalidSyntaxException) throwable).getLocation());
+                }
+
+                graphQLErrors.add(errorBuilder.build());
             }
         }
 


### PR DESCRIPTION
When running a mutation without an argument and resolver accepts nullable arguments, a throwable is thrown without a message and therefore we get this error: 
```
2019-10-03 01:06:30.765 GMT
graphql.AssertException: Object required to be not null at graphql.Assert.assertNotNull(Assert.java:22) at graphql.GraphqlErrorBuilder.message(GraphqlErrorBuilder.java:53) at com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation.convertErrors(FederatedTracingInstrumentation.java:170) at com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation.lambda$beginFieldFetch$0(FederatedTracingInstrumentation.java:121) at graphql.execution.instrumentation.SimpleInstrumentationContext.onCompleted(SimpleInstrumentationContext.java:48)
```

this PR adds a null check to avoid running into this 