### PR TITLE
Fixed concurrency bug in FederatedTracingState

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -28,10 +28,10 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
 import static graphql.schema.GraphQLTypeUtil.simplePrint;
@@ -198,7 +198,7 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
     private static class FederatedTracingState implements InstrumentationState {
         private final Instant startRequestTime;
         private final long startRequestNanos;
-        private final ConcurrentHashMap<ExecutionPath, Reports.Trace.Node.Builder> nodesByPath;
+        private final ConcurrentMap<ExecutionPath, Reports.Trace.Node.Builder> nodesByPath;
 
         private FederatedTracingState() {
             // record start time when creating instrumentation state for a request

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -31,6 +31,7 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static graphql.execution.instrumentation.SimpleInstrumentationContext.whenCompleted;
 import static graphql.schema.GraphQLTypeUtil.simplePrint;
@@ -197,14 +198,14 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
     private static class FederatedTracingState implements InstrumentationState {
         private final Instant startRequestTime;
         private final long startRequestNanos;
-        private final LinkedHashMap<ExecutionPath, Reports.Trace.Node.Builder> nodesByPath;
+        private final ConcurrentHashMap<ExecutionPath, Reports.Trace.Node.Builder> nodesByPath;
 
         private FederatedTracingState() {
             // record start time when creating instrumentation state for a request
             startRequestTime = Instant.now();
             startRequestNanos = System.nanoTime();
 
-            nodesByPath = new LinkedHashMap<>();
+            nodesByPath = new ConcurrentHashMap<>();
             nodesByPath.put(ExecutionPath.rootPath(), Reports.Trace.Node.newBuilder());
         }
 


### PR DESCRIPTION
Changed `LinkedHashMap` to `ConcurrentHashMap` in `FederatedTracingState` since `addNode()` may be called by multiple threads, causing concurrent puts to the map. 

Paired with @zionts