### PR TITLE
Render descriptions as BlockStrings if necessary

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationSdlPrinter.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationSdlPrinter.java
@@ -932,14 +932,16 @@ public class FederationSdlPrinter {
             List<String> lines = Arrays.asList(descriptionText.split("\n"));
             if (options.isDescriptionsAsHashComments()) {
                 printMultiLineHashDescription(out, prefix, lines);
+            } else if (needsBlockString(descriptionText)) {
+                printMultiLineDescription(out, prefix, lines);
             } else {
-                if (lines.size() > 1) {
-                    printMultiLineDescription(out, prefix, lines);
-                } else {
-                    printSingleLineDescription(out, prefix, lines.get(0));
-                }
+                printSingleLineDescription(out, prefix, descriptionText);
             }
         }
+    }
+
+    private boolean needsBlockString(String description) {
+        return description.contains("\"") || description.contains("\n") | description.contains("\r");
     }
 
     private void printMultiLineHashDescription(PrintWriter out, String prefix, List<String> lines) {

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
@@ -8,7 +8,11 @@ type Money {
 }
 
 type Product @key(fields : "upc") {
+  """
+  The product "name".
+  """
   name: String
+  "Price in pennies"
   price: Int
   sku: String!
   upc: String!


### PR DESCRIPTION
Currently, quotes within decription strings result in unparseable schema from _Service.sdl

Example:

```graphql
type Query {
    """Field docstring contains a "quoted" field."""
    fooField: String
}
```

When queried from sdl becomes

```graphql
schema {
  query: Query
}

type Query {
 "Field docstring contains a "quoted" field."
  fooField: String
}
```

In this case, the description string should be surrounded in triple quotes as in the original schema.
We should force triple-quotes if there are any characters that can't be contained in a graphql [StringValue](https://spec.graphql.org/draft/#sec-String-Value) (`"`, `\`, or `LineTerminator`)

See also https://github.com/apollographql/federation-jvm/issues/71