### PR TITLE
graphql-java-support: Fix bad escaping for descriptions in graphql-java's SchemaPrinter

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationSdlPrinter.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationSdlPrinter.java
@@ -953,7 +953,43 @@ public class FederationSdlPrinter {
     }
 
     private void printSingleLineDescription(PrintWriter out, String prefix, String s) {
-        out.printf("%s\"%s\"\n", prefix, s);
+        // See: https://github.com/graphql/graphql-spec/issues/148
+        String desc = escapeJsonString(s);
+        out.printf("%s\"%s\"\n", prefix, desc);
+    }
+
+    private String escapeJsonString(String stringValue) {
+        int len = stringValue.length();
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            char ch = stringValue.charAt(i);
+            switch (ch) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    sb.append(ch);
+            }
+        }
+        return sb.toString();
     }
 
     private boolean hasDescription(Object descriptionHolder) {

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -35,6 +35,8 @@ class FederationTest {
     private final String isolatedSDL = TestUtils.readResource("schemas/isolated.graphql");
     private final String productSDL = TestUtils.readResource("schemas/product.graphql");
     private final String printerEmptySDL = TestUtils.readResource("schemas/printerEmpty.graphql");
+    private final String printerEscapingSDL = TestUtils.readResource("schemas/printerEscaping.graphql");
+    private final String printerEscapingExpectedSDL = TestUtils.readResource("schemas/printerEscapingExpected.graphql");
     private final String printerFilterSDL = TestUtils.readResource("schemas/printerFilter.graphql");
     private final String printerFilterExpectedSDL = TestUtils.readResource("schemas/printerFilterExpected.graphql");
     private final Set<String> standardDirectives =
@@ -175,6 +177,21 @@ class FederationTest {
         );
         Assertions.assertEquals(
                 printerEmptySDL.trim(),
+                new FederationSdlPrinter(FederationSdlPrinter.Options.defaultOptions()
+                        .includeDirectiveDefinitions(def -> !standardDirectives.contains(def.getName()))
+                ).print(graphQLSchema).trim()
+        );
+    }
+
+    @Test
+    void testPrinterEscaping() {
+        TypeDefinitionRegistry typeDefinitionRegistry = new SchemaParser().parse(printerEscapingSDL);
+        GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(
+                typeDefinitionRegistry,
+                RuntimeWiring.newRuntimeWiring().build()
+        );
+        Assertions.assertEquals(
+                printerEscapingExpectedSDL.trim(),
                 new FederationSdlPrinter(FederationSdlPrinter.Options.defaultOptions()
                         .includeDirectiveDefinitions(def -> !standardDirectives.contains(def.getName()))
                 ).print(graphQLSchema).trim()

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerEscaping.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerEscaping.graphql
@@ -1,0 +1,16 @@
+type Query {
+  "escaped\"quotes"
+  field1: String
+  "escaped\\backslash"
+  field2: String
+  "escaped\bbackspace"
+  field3: String
+  "escaped\fform feed"
+  field4: String
+  "escaped\nnewline"
+  field5: String
+  "escaped\rcarriage return"
+  field6: String
+  "escaped\ttab"
+  field7: String
+}

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerEscapingExpected.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerEscapingExpected.graphql
@@ -1,0 +1,19 @@
+type Query {
+  "escaped\"quotes"
+  field1: String
+  "escaped\\backslash"
+  field2: String
+  "escaped\bbackspace"
+  field3: String
+  "escaped\fform feed"
+  field4: String
+  """
+  escaped
+  newline
+  """
+  field5: String
+  "escaped\rcarriage return"
+  field6: String
+  "escaped\ttab"
+  field7: String
+}


### PR DESCRIPTION
`graphql-java` v14's `SchemaPrinter` does not escape characters properly in single-quoted descriptions as required by spec. This has affected users of `federation-jvm`, as shown in #71 .

It's been fixed upstream by graphql-java/graphql-java#1832 , but this has been released in `graphql-java` v15 and has not been backported to `graphql-java` v14. This PR backports the fix to `FederationSdlPrinter` for v14 users. I've added a basic test to `FederationTest` to check behavior for the relevant characters in the backfix.

For reviewing, it'll help to look at [`printSingleLineDescription()`](https://github.com/graphql-java/graphql-java/blob/v15.0/src/main/java/graphql/schema/idl/SchemaPrinter.java#L935) in the v15 `SchemaPrinter`, along with [`escapeJsonString`](https://github.com/graphql-java/graphql-java/blob/v15.0/src/main/java/graphql/util/EscapeUtil.java#L15) in `EscapeUtil.java`.