### PR TITLE
support excluding directives in FederationSdlPrinter #79

### DIFF
--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerFilterDirective.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerFilterDirective.graphql
@@ -1,0 +1,44 @@
+directive @directive1 on FIELD_DEFINITION
+
+directive @directive2 on OBJECT
+
+interface Interface1 {
+  dummy: Enum2 @directive1
+}
+
+interface Interface2 {
+  dummy: Interface1 @directive1
+}
+
+type Object1 @directive2 {
+  dummy: Scalar2 @directive1
+}
+
+type Object2 @directive2 {
+  dummy: Object1 @directive1
+}
+
+type Query {
+  dummyEnum: Enum1 @directive1
+  dummyScalar: Scalar1 @directive1
+}
+
+enum Enum1 {
+  DUMMY
+}
+
+enum Enum2 {
+  DUMMY
+}
+
+scalar Scalar1
+
+scalar Scalar2
+
+input InputObject1 {
+  dummy: String
+}
+
+input InputObject2 {
+  dummy: InputObject1
+}

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerFilterDirectiveExpected.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerFilterDirectiveExpected.graphql
@@ -1,0 +1,22 @@
+interface Interface2 {
+  dummy: Interface1 @directive1
+}
+
+type Object2 {
+  dummy: Object1 @directive1
+}
+
+type Query {
+  dummyEnum: Enum1 @directive1
+  dummyScalar: Scalar1 @directive1
+}
+
+enum Enum2 {
+  DUMMY
+}
+
+scalar Scalar2
+
+input InputObject2 {
+  dummy: InputObject1
+}


### PR DESCRIPTION
This is an extension for https://github.com/apollographql/federation-jvm/pull/53 

Use Case:
There are some server side directives(_mappedType, _mappedInputField and _mappedOperation) added to original schema by graphql-spqr library which do not have directive definitions exposed in the schema. 

grapqhl-spqr is correct in not exposing the server side directive definitions as per Graph Spec.

These directives break the Apollo Gateway while discovering the schema of the service.

As part of this fix, i have added support for excluding such directives.

Related https://github.com/leangen/graphql-spqr/issues/290