### PR TITLE
Update to graphql-java v16.1

### DIFF
--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -15,6 +15,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
         </dependency>

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -88,20 +88,11 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
             logger.debug(trace.toString());
         }
 
-        // Elaborately copy the result into a builder.
-        // Annoyingly, ExecutionResultImpl.Builder.from takes ExecutionResultImpl rather than
-        // ExecutionResult in versions of GraphQL-Java older than v13
-        // (see https://github.com/graphql-java/graphql-java/pull/1491), so to support older versions
-        // we copy the fields by hand, which does result in isDataPresent always being set (ie,
-        // "data": null being included in all results). The built-in TracingInstrumentation has
-        // the same issue. If we decide to only support v13 then this can just change to
-        // ExecutionResultImpl.newExecutionResult().from(executionResult).
-        return CompletableFuture.completedFuture(ExecutionResultImpl.newExecutionResult()
-                .data(executionResult.getData())
-                .errors(executionResult.getErrors())
-                .extensions(executionResult.getExtensions())
-                .addExtension(EXTENSION_KEY, Base64.getEncoder().encodeToString(trace.toByteArray()))
-                .build());
+        return CompletableFuture.completedFuture(
+                ExecutionResultImpl
+                        .newExecutionResult().from(executionResult)
+                        .addExtension(EXTENSION_KEY, Base64.getEncoder().encodeToString(trace.toByteArray()))
+                        .build());
     }
 
     @Override

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -58,6 +58,7 @@ class FederationTest {
                 "\n" +
                 "type Query {\n" +
                 "  _service: _Service\n" +
+                "  dummy: String\n" +
                 "}\n" +
                 "\n" +
                 "type _Service {\n" +
@@ -165,9 +166,6 @@ class FederationTest {
         TypeDefinitionRegistry typeDefinitionRegistry = new SchemaParser().parse(printerEmptySDL);
         RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
                 .type("Interface1", typeWiring -> typeWiring
-                        .typeResolver(env -> null)
-                )
-                .type("Interface2", typeWiring -> typeWiring
                         .typeResolver(env -> null)
                 )
                 .build();

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/empty.graphql
@@ -2,4 +2,6 @@ schema {
   query: Query
 }
 
-type Query
+type Query {
+  dummy: String
+}

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/interfaces.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/interfaces.graphql
@@ -1,3 +1,7 @@
+type Query {
+    dummy: String
+}
+
 interface Product @key(fields : "id") {
     id: ID!
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/isolated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/isolated.graphql
@@ -1,4 +1,6 @@
-type Query
+type Query {
+    dummy: String
+}
 
 type SomeType @key(fields: "theKey") {
     theKey: ID!

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerEmpty.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/printerEmpty.graphql
@@ -1,25 +1,19 @@
-interface Interface1
-
-interface Interface2 {
+interface Interface1 {
   dummy: String
 }
 
-type Object1
-
-type Object2 {
+type Object1 {
   dummy: String
 }
 
-type Query
+type Query {
+  hello: Object1
+}
 
-enum Enum1
-
-enum Enum2 {
+enum Enum1 {
   DUMMY
 }
 
-input InputObject1
-
-input InputObject2 {
+input InputObject1 {
   dummy: String
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
@@ -14,4 +14,6 @@ type Product @key(fields : "upc") {
   upc: String!
 }
 
-type Query
+type Query {
+  dummy: String
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <graphql-java.version>15.0</graphql-java.version>
+        <graphql-java.version>16.1</graphql-java.version>
         <graphql-spring-boot.version>5.10.0</graphql-spring-boot.version>
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <graphql-java.version>15.0</graphql-java.version>
         <graphql-spring-boot.version>5.10.0</graphql-spring-boot.version>
         <java.version>1.8</java.version>

--- a/spring-example/src/main/resources/schemas/inventory.graphql
+++ b/spring-example/src/main/resources/schemas/inventory.graphql
@@ -1,3 +1,7 @@
+type Query {
+    dummy: String
+}
+
 type Product @key(fields: "upc") @extends {
     upc: String! @external
     inStock: Boolean


### PR DESCRIPTION
Some breaking changes in this one:

- ExecutionPath was renamed to ResultPath: https://github.com/graphql-java/graphql-java/pull/1962
- Validations do not allow types with no fields anymore: https://github.com/graphql-java/graphql-java/pull/1955

The tests were updated to pass the new validations, but it feels a bit hackish so maybe someone with more knowledge of the test cases/infrastructure should take a closer look. The problem is that the federation transformations are applied too late so some types are empty during validation.