### PR TITLE
graphql-java-support: Fix bug where we ignore extended query types when checking if the query type is empty

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -14,6 +14,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.Reader;
+import java.util.List;
+import java.util.Optional;
 
 public final class Federation {
     private static final SchemaGenerator.Options generatorOptions = SchemaGenerator.Options.defaultOptions();
@@ -92,7 +94,11 @@ public final class Federation {
                 .getType(queryName)
                 .orElse(ObjectTypeDefinition.newObjectTypeDefinition().name(queryName).build());
         final boolean addDummyField = newQueryType instanceof ObjectTypeDefinition
-                && ((ObjectTypeDefinition) newQueryType).getFieldDefinitions().isEmpty();
+                && ((ObjectTypeDefinition) newQueryType).getFieldDefinitions().isEmpty()
+                && Optional.ofNullable(typeRegistry.objectTypeExtensions().get(queryName))
+                    // Note that an object type extension must have at least one field
+                    .map(List::isEmpty)
+                    .orElse(true);
         if (addDummyField) {
             newQueryType = ((ObjectTypeDefinition) newQueryType).transform(objectTypeDefinitionBuilder ->
                     objectTypeDefinitionBuilder.fieldDefinition(FieldDefinition.newFieldDefinition()

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -31,6 +31,11 @@ class FederationTest {
     private final String emptySDL = TestUtils.readResource("schemas/empty.graphql");
     private final String emptyFederatedSDL = TestUtils.readResource("schemas/emptyFederated.graphql");
     private final String emptySchemaFederatedSDL = TestUtils.readResource("schemas/emptySchemaFederated.graphql");
+    private final String emptyWithExtendQuerySDL = TestUtils.readResource("schemas/emptyWithExtendQuery.graphql");
+    private final String emptyWithExtendQueryFederatedSDL =
+            TestUtils.readResource("schemas/emptyWithExtendQueryFederated.graphql");
+    private final String emptyWithExtendQueryServiceSDL =
+            TestUtils.readResource("schemas/emptyWithExtendQueryService.graphql");
     private final String interfacesSDL = TestUtils.readResource("schemas/interfaces.graphql");
     private final String isolatedSDL = TestUtils.readResource("schemas/isolated.graphql");
     private final String productSDL = TestUtils.readResource("schemas/product.graphql");
@@ -43,6 +48,12 @@ class FederationTest {
     void testEmptySDL() {
         final GraphQLSchema federatedSchema = Federation.transform(emptySDL).build();
         SchemaUtils.assertSDL(federatedSchema, emptyFederatedSDL, emptySDL);
+    }
+
+    @Test
+    void testEmptyWithExtendQuerySDL() {
+        final GraphQLSchema federatedSchema = Federation.transform(emptyWithExtendQuerySDL).build();
+        SchemaUtils.assertSDL(federatedSchema, emptyWithExtendQueryFederatedSDL, emptyWithExtendQueryServiceSDL);
     }
 
     @Test

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaUtils.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaUtils.java
@@ -1,16 +1,28 @@
 package com.apollographql.federation.graphqljava;
 
 import graphql.ExecutionResult;
+import graphql.Scalars;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import org.junit.jupiter.api.Assertions;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static graphql.ExecutionInput.newExecutionInput;
 import static graphql.GraphQL.newGraphQL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class SchemaUtils {
+    static public final Set<String> standardDirectives =
+            new HashSet<>(Arrays.asList("deprecated", "include", "skip", "specifiedBy"));
 
     private SchemaUtils() {
     }
@@ -19,7 +31,27 @@ final class SchemaUtils {
         return newGraphQL(schema).build().execute(newExecutionInput().query(query).build());
     }
 
-    static void assertSDL(GraphQLSchema schema, String expected) {
+    static void assertSDL(GraphQLSchema schema, String expectedSchemaSDL, String expectedServiceSDL) {
+        if (expectedSchemaSDL != null) {
+            Assertions.assertEquals(
+                    expectedSchemaSDL.trim(),
+                    new FederationSdlPrinter(FederationSdlPrinter.Options.defaultOptions()
+                            .includeScalarTypes(true)
+                            .includeDirectiveDefinitions(def -> !standardDirectives.contains(def.getName()))
+                    ).print(schema).trim()
+            );
+        }
+
+        final GraphQLFieldDefinition serviceField = schema.getQueryType().getFieldDefinition("_service");
+        assertNotNull(serviceField, "_service field present");
+        final GraphQLType serviceType = schema.getType("_Service");
+        assertNotNull(serviceType, "_Service type present");
+        assertTrue(serviceType instanceof GraphQLObjectType, "_Service type is object type");
+        assertEquals(serviceType, serviceField.getType(), "_service returns _Service");
+        final GraphQLFieldDefinition sdlField = ((GraphQLObjectType) serviceType).getFieldDefinition("sdl");
+        assertNotNull(sdlField, "sdl field present");
+        assertTrue(GraphQLNonNull.nonNull(Scalars.GraphQLString).isEqualTo(sdlField.getType()), "sdl returns String!");
+
         final ExecutionResult inspect = execute(schema, "{_service{sdl}}");
         assertEquals(0, inspect.getErrors().size(), "No errors");
         final Map<String, Object> data = inspect.getData();
@@ -27,6 +59,6 @@ final class SchemaUtils {
         @SuppressWarnings("unchecked") final Map<String, Object> _service = (Map<String, Object>) data.get("_service");
         assertNotNull(_service);
         final String sdl = (String) _service.get("sdl");
-        assertEquals(expected.trim(), sdl.trim());
+        assertEquals(expectedServiceSDL.trim(), sdl.trim());
     }
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyFederated.graphql
@@ -1,0 +1,19 @@
+directive @extends on OBJECT | INTERFACE
+
+directive @external on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+type Query {
+  _service: _Service
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _FieldSet

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptySchemaFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptySchemaFederated.graphql
@@ -1,0 +1,7 @@
+type Query {
+  _service: _Service
+}
+
+type _Service {
+  sdl: String!
+}

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQuery.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQuery.graphql
@@ -1,0 +1,9 @@
+schema {
+  query: Query
+}
+
+type Query
+
+extend type Query {
+  field1: String
+}

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQueryFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQueryFederated.graphql
@@ -1,0 +1,20 @@
+directive @extends on OBJECT | INTERFACE
+
+directive @external on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+type Query {
+  _service: _Service
+  field1: String
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _FieldSet

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQueryService.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQueryService.graphql
@@ -1,0 +1,7 @@
+schema {
+  query: Query
+}
+
+type Query {
+  field1: String
+}


### PR DESCRIPTION
As reported in #88 , there's a bug that occurs when a user gives us a schema with an empty query type but contains query type extensions. We don't check for query type extensions in `Federation.ensureQueryTypeExists()`, so we end up setting `queryTypeShouldBeEmpty` to `true` and mistakenly removing fields from those extensions.

This PR:
- Refactors tests a bit to be cleaner, namely moving blobs of text to .graphql files and factoring out some common asserts.
- Adds a test for the above case.
- Changes `Federation.ensureQueryTypeExists()` to check for query type extensions (note that a type extension must have at least one field).