### PR TITLE
fix key directive should be repeatable

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -61,7 +61,7 @@ public final class FederationDirectives {
             .type(new NonNullType(new TypeName(_FieldSet.typeName)))
             .build();
 
-    /* directive @key(fields: _FieldSet!) on OBJECT | INTERFACE */
+    /* directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE */
 
     public static final String keyName = "key";
 
@@ -75,7 +75,6 @@ public final class FederationDirectives {
     public static GraphQLDirective key(String fields) {
         return newDirective(key)
                 .argument(fieldsArgument(fields))
-                .repeatable(true)
                 .build();
     }
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -69,11 +69,13 @@ public final class FederationDirectives {
             .name(keyName)
             .validLocations(OBJECT, INTERFACE)
             .argument(fieldsArgument)
+            .repeatable(true)
             .build();
 
     public static GraphQLDirective key(String fields) {
         return newDirective(key)
                 .argument(fieldsArgument(fields))
+                .repeatable(true)
                 .build();
     }
 
@@ -81,6 +83,7 @@ public final class FederationDirectives {
             .name(keyName)
             .directiveLocations(Arrays.asList(DL_OBJECT, DL_INTERFACE))
             .inputValueDefinition(fieldsDefinition)
+            .repeatable(true)
             .build();
 
     /* directive @external on FIELD_DEFINITION */

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -99,7 +99,7 @@ public final class SchemaTransformer {
         // Collecting all entity types: Types with @key directive and all types that implement them
         final Set<String> entityTypeNames = originalSchema.getAllTypesAsList().stream()
                 .filter(t -> t instanceof GraphQLDirectiveContainer &&
-                        ((GraphQLDirectiveContainer) t).getDirective(FederationDirectives.keyName) != null)
+                        !((GraphQLDirectiveContainer) t).getDirectives(FederationDirectives.keyName).isEmpty())
                 .map(GraphQLNamedType::getName)
                 .collect(Collectors.toSet());
 

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyFederated.graphql
@@ -2,7 +2,7 @@ directive @extends on OBJECT | INTERFACE
 
 directive @external on FIELD_DEFINITION
 
-directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQueryFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/emptyWithExtendQueryFederated.graphql
@@ -2,7 +2,7 @@ directive @extends on OBJECT | INTERFACE
 
 directive @external on FIELD_DEFINITION
 
-directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
 
 directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/product.graphql
@@ -7,7 +7,7 @@ type Money {
   currencyCode: String! @deprecated(reason : "dummy")
 }
 
-type Product @key(fields : "upc") {
+type Product @key(fields : "upc") @key(fields : "sku") {
   name: String
   price: Int
   sku: String!


### PR DESCRIPTION
## Description

When using multiple @key directives on a type, an [AssertException](https://github.com/graphql-java/graphql-java/blob/b01df7449bebef5bd645f0255a94d8eaacfa0a5c/src/main/java/graphql/DirectivesUtil.java#L146) (this was a graphql-java 16 change) is triggered in the SchemaTransformer since the key directive is defined to be non repeatable. 

## Fix & Testing

The fix consists of switching the key directive to be repeatable as well as using `GraphQLDirectiveContainer.getDirectives()` instead of `GraphQLDirectiveContainer.getDirective()` (singular) reserved for non repeatable directives only.

I added an additional @key in one of the schemas in the tests to reproduce the issue. 

