### PR TITLE
Clean up POMs, add GPG signing, and switch publish pipeline to Maven Central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           key: cache-{{ checksum "allpoms.xml" }}
       - run:
           name: Build, install, test
-          command: ./mvnw --settings settings.xml --batch-mode install test
+          command: ./mvnw --settings settings.xml --batch-mode install test -Dgpg.skip
       - run:
           name: Save test results
           command: |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 # Apollo Federation on the JVM
 
-Packages published to [our bintray repository](https://bintray.com/apollographql/maven/federation-jvm)
-and available [in jcenter](https://jcenter.bintray.com/com/apollographql/federation/);
-release notes in [RELEASE_NOTES.md](RELEASE_NOTES.md).
+Packages published to Maven Central; release notes in [RELEASE_NOTES.md](RELEASE_NOTES.md). Note that older versions of this package may only be available in JCenter, but we are planning to republish these versions to Maven Central.
 
 An example of [graphql-spring-boot](https://www.graphql-java-kickstart.com/spring-boot/) microservice is available in [spring-example](spring-example).
 
@@ -14,11 +12,11 @@ An example of [graphql-spring-boot](https://www.graphql-java-kickstart.com/sprin
 
 ### Dependency management with Gradle
 
-Make sure JCenter is among your repositories:
+Make sure Maven Central is among your repositories:
 
 ```groovy
 repositories {
-    jcenter()
+    mavenCentral()
 }
 ```
 
@@ -78,12 +76,11 @@ HTTP request's headers, by making the `context` part of your `ExecutionInput`
 implement the `HTTPRequestHeaders` interface.  For example:
 
 ```java
-    HTTPRequestHeaders context = new HTTPRequestHeaders() {
-        @Override
-        public @Nullable String getHTTPRequestHeader(String caseInsensitiveHeaderName) {
-            return myIncomingHTTPRequest.getHeader(caseInsensitiveHeaderName);
-        }
+HTTPRequestHeaders context = new HTTPRequestHeaders() {
+    @Override
+    public @Nullable String getHTTPRequestHeader(String caseInsensitiveHeaderName) {
+        return myIncomingHTTPRequest.getHeader(caseInsensitiveHeaderName);
     }
-    graphql.execute(ExecutionInput.newExecutionInput(queryString).context(context));
-
+};
+graphql.execute(ExecutionInput.newExecutionInput(queryString).context(context));
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,18 @@
 # Releasing this package
 
 
-## One-time setup
-- Sign up for an account at bintray.com
-- Ask an admin to add you to the apollographql organization (eg pcarrier or glasser)
-- Create an API key in your Bintray profile
+## One-time Sonatype setup
+- Sign up for a Jira account at [https://issues.sonatype.org/](https://issues.sonatype.org/). Note that these are the credentials you'll use to publish to Maven Central.
+- [Create a Jira task](https://issues.sonatype.org/secure/CreateIssue!default.jspa) on Sonatype's OSSRH board, asking for access to the group ID `com.apollographql.federation` so that you can publish this package. For an example of what this looks like, see [OSSRH-65026](https://issues.sonatype.org/browse/OSSRH-65026).
+- Slack one of Martin Bonnin, Sachin Shinde, or Martijn Walraven, and ask them to comment on the created Jira task, to confirm that you should have access.
+- Within a business day (hopefully), a Sonatype representative should reply and confirm that your permissions have been granted.
+
+## One-time GPG setup
+- Install `gpg` on your computer. You'll need this to sign files you upload to Maven Central, as Sonatype requires them to be signed.
+- Ensure `gpg` is on your computer's path environment variable, as this is how Maven discovers it.
+- Apollo uses a shared GPG key for Maven Central signing, located in 1Password. Copy-paste the private key (the block starting with `-----BEGIN PGP PRIVATE KEY BLOCK-----` and ending with `-----END PGP PRIVATE KEY BLOCK-----`) into a file called `private.key`.
+- Run `gpg --import private.key`. A prompt will appear asking you for the passphrase; get this from 1Password as well.
+- Delete the `private.key` file.
 
 ## For each release
 - Start a branch `release-VERSION`
@@ -12,8 +20,9 @@
 - Edit all instances of (next version)-SNAPSHOT in all pom.xml files to be the desired version
 - Edit version in Gradle section of README.md
 - Push branch, open PR, wait for CI to pass
-- Run `BINTRAY_USER=username BINTRAY_API_KEY=apikey ./mvnw --settings settings.xml clean deploy`
-- `git tag vVERSION && git push origin vVERSION`
+- Run `SONATYPE_USERNAME=username SONATYPE_PASSWORD=password ./mvnw --settings settings.xml clean deploy`
+- A prompt will appear asking you for the GPG passphrase; get this from 1Password
+- Run `git tag vVERSION && git push origin vVERSION`
 - Edit all instances of the version in all pom.xml files to be the next patch release plus `-SNAPSHOT`
 - Push branch again
 - Merge PR

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -89,6 +89,10 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -82,6 +82,10 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -11,7 +11,9 @@
     </parent>
 
     <artifactId>federation-graphql-java-support</artifactId>
+
     <name>federation-graphql-java-support</name>
+    <description>GraphQL Java server support for Apollo Federation</description>
 
     <dependencies>
         <dependency>
@@ -53,32 +55,12 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-            </plugin>
-
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
-                <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.9.0:exe:${os.detected.classifier}</protocArtifact>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -87,6 +69,21 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:3.9.0:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,17 +6,17 @@
 
     <groupId>com.apollographql.federation</groupId>
     <artifactId>federation-parent</artifactId>
-    <name>federation-parent</name>
     <version>0.6.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <name>federation-parent</name>
+    <description>The parent POM for all federation-jvm projects</description>
     <url>https://github.com/apollographql/federation-jvm</url>
-
+    <inceptionYear>2019</inceptionYear>
     <organization>
-        <name>Meteor Development Group</name>
+        <name>Apollo Graph Inc.</name>
         <url>https://www.apollographql.com/about-us</url>
     </organization>
-
     <licenses>
         <license>
             <name>MIT License</name>
@@ -25,24 +25,34 @@
         </license>
     </licenses>
 
-    <inceptionYear>2019</inceptionYear>
-
     <developers>
         <developer>
             <id>apollographql.com</id>
             <name>The Apollo Contributors</name>
             <url>https://www.apollographql.com/careers/team</url>
-            <organization>Meteor Development Group</organization>
+            <organization>Apollo Graph Inc.</organization>
             <organizationUrl>https://www.apollographql.com/about-us</organizationUrl>
         </developer>
     </developers>
 
+    <modules>
+        <module>graphql-java-support</module>
+        <module>spring-example</module>
+    </modules>
+
     <scm>
-        <url>https://github.com/apollographql/federation-jvm</url>
         <connection>scm:git:git://github.com/apollographql/federation-jvm.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/apollographql/federation-jvm.git</developerConnection>
         <tag>HEAD</tag>
+        <url>https://github.com/apollographql/federation-jvm</url>
     </scm>
+    <distributionManagement>
+        <repository>
+            <id>bintray-apollographql-maven</id>
+            <name>apollographql-maven</name>
+            <url>https://api.bintray.com/maven/apollographql/maven/federation-jvm/;publish=1</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <release>0.6.3-SNAPSHOT</release>
@@ -63,19 +73,6 @@
         <slf4j.version>1.7.30</slf4j.version>
         <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     </properties>
-
-    <modules>
-        <module>graphql-java-support</module>
-        <module>spring-example</module>
-    </modules>
-
-    <distributionManagement>
-        <repository>
-            <id>bintray-apollographql-maven</id>
-            <name>apollographql-maven</name>
-            <url>https://api.bintray.com/maven/apollographql/maven/federation-jvm/;publish=1</url>
-        </repository>
-    </distributionManagement>
 
     <dependencyManagement>
         <dependencies>
@@ -142,31 +139,17 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven-deploy-plugin.version}</version>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                        <!-- Workaround from https://stackoverflow.com/questions/50661648/spring-boot-fails-to-run-maven-surefire-plugin-classnotfoundexception-org-apache/50661649#50661649 -->
+                        <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>${maven-javadoc-plugin.version}</version>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <!-- protobuf generated java classes are missing various tags, so disable 'missing' -->
-                        <doclint>all,-missing</doclint>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -183,17 +166,31 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin.version}</version>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                     <configuration>
-                        <!-- Workaround from https://stackoverflow.com/questions/50661648/spring-boot-fails-to-run-maven-surefire-plugin-classnotfoundexception-org-apache/50661649#50661649 -->
-                        <useSystemClassLoader>false</useSystemClassLoader>
+                        <notimestamp>true</notimestamp>
+                        <!-- protobuf generated java classes are missing various tags, so disable 'missing' -->
+                        <doclint>all,-missing</doclint>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
                     <version>${cobertura-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
         <junit.version>5.4.2</junit.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
@@ -186,6 +187,19 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
                     <version>${cobertura-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
         <url>https://github.com/apollographql/federation-jvm</url>
     </scm>
     <distributionManagement>
-        <repository>
-            <id>bintray-apollographql-maven</id>
-            <name>apollographql-maven</name>
-            <url>https://api.bintray.com/maven/apollographql/maven/federation-jvm/;publish=1</url>
-        </repository>
+        <snapshotRepository>
+            <id>sonatype-ossrh</id>
+            <name>Sonatype OSS Repository Hosting Service</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <properties>
@@ -65,12 +65,12 @@
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
         <junit.version>5.4.2</junit.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
     </properties>
@@ -202,9 +202,15 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven-deploy-plugin.version}</version>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>sonatype-ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -9,4 +9,15 @@
             <password>${env.BINTRAY_API_KEY}</password>
         </server>
     </servers>
+    <profiles>
+        <profile>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <!-- This is the public fingerprint for the Apollo PGP key -->
+                <gpg.keyname>5A446C80C27E095353CF3969F165A96372E61948</gpg.keyname>
+            </properties>
+        </profile>
+    </profiles>
 </settings>

--- a/settings.xml
+++ b/settings.xml
@@ -4,9 +4,9 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>bintray-apollographql-maven</id>
-            <username>${env.BINTRAY_USER}</username>
-            <password>${env.BINTRAY_API_KEY}</password>
+            <id>sonatype-ossrh</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
         </server>
     </servers>
     <profiles>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -11,7 +11,9 @@
     </parent>
 
     <artifactId>federation-spring-example</artifactId>
+
     <name>federation-spring-example</name>
+    <description>Spring Boot example of federation-graphql-java-support usage</description>
 
     <dependencies>
         <dependency>
@@ -61,7 +63,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -74,6 +74,10 @@
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -66,6 +66,10 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
This PR addresses #95. More specifically, this PR:
- Adds any missing metadata to POMs that Maven Central requires for publishing (we were missing `<description>` everywhere).
- Updates old metadata (`Meteor Development Group` -> `Apollo Graph Inc.`), sorts POMs using [conventional order](https://maven.apache.org/ref/3.6.3/maven-model/maven.html), removes unneeded default plugin declarations.
- Changes `spring-example` to generate javadocs.
- Adds a GPG signing plugin and disables it in CI.
- Switches from deploying to Bintray to deploying to Sonatype OSSRH.
- Updates releasing docs to describe how to get a Sonatype account and how to setup GPG, along with changes to the deploy process.
- Updates the readme for the switch to Maven Central.

The next step will be testing the Maven Central deployment flow with an RC; we'll do some testing in our infra after, and if all goes well, we'll cut an actual release.