### PR TITLE
**/pom.xml: Move deploy plugin to parent POM

### DIFF
--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -89,10 +89,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -219,5 +219,11 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -74,10 +74,6 @@
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
The `nexus-staging-maven-plugin` plugin declaration needs to be in the parent POM, since `federation-parent` requires it to replace the default deploy plugin.