### PR TITLE
**/pom.xml: Move GPG signing plugin to parent POM

### DIFF
--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -82,10 +82,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,10 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
             </plugin>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -66,10 +66,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
The `maven-gpg-plugin` plugin declaration needs to be in the parent POM, since `federation-parent` is required to have its files be signed.