### PR TITLE
graphql-spring-example: Update docs to add -Dgpg.skip to mvn install invocation

### DIFF
--- a/spring-example/README.md
+++ b/spring-example/README.md
@@ -2,7 +2,7 @@
 To run the example, cd to the root of this project, then...
 ```
 ## compile and install project including example and dependencies
-mvn install
+mvn install -Dgpg.skip
 ## start local webserver on 9000
 mvn -pl spring-example spring-boot:run
 ```


### PR DESCRIPTION
Right now, following the instructions of `spring-example/README.md` leads to a GPG-signing prompt when running `mvn install`. To avoid this, this PR updates the docs so this command is instead `mvn install -Dgpg.skip`, which skips GPG signing.