### PR TITLE
**/pom.xml: Description change, remove unneeded extensions, use properties in dependency versions

### DIFF
--- a/graphql-java-support-api/pom.xml
+++ b/graphql-java-support-api/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>federation-graphql-java-support-api</artifactId>
 
     <name>federation-graphql-java-support-api</name>
-    <description>GraphQL Java server support for Apollo Federation API</description>
+    <description>Integration APIs for federation-graphql-java-support</description>
 
     <dependencies>
         <dependency>
@@ -23,13 +23,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.0</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.apollographql.federation</groupId>
             <artifactId>federation-graphql-java-support</artifactId>
-            <version>0.6.5-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
I've tidied up the `pom.xml` files a bit. Specifically:
- The description for `federation-graphql-java-support-api` has been updated.
- The extension `os-maven-plugin` has been removed from `federation-graphql-java-support-api`.
- The inter-module dependencies have been changed to use version `${project.version}`.