### PR TITLE
README.md: Reformat, and clarify example around federated tracing predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 # Apollo Federation on the JVM
 
-Packages published to Maven Central; release notes in [RELEASE_NOTES.md](RELEASE_NOTES.md). Note that older versions of this package may only be available in JCenter, but we are planning to republish these versions to Maven Central.
+Packages published to Maven Central; release notes in [RELEASE_NOTES.md](RELEASE_NOTES.md). Note that older versions of
+this package may only be available in JCenter, but we are planning to republish these versions to Maven Central.
 
-An example of [graphql-spring-boot](https://www.graphql-java-kickstart.com/spring-boot/) microservice is available in [spring-example](spring-example).
+An example of [graphql-spring-boot](https://www.graphql-java-kickstart.com/spring-boot/) microservice is available
+in [spring-example](spring-example).
 
 ## Getting started
 
@@ -30,24 +32,27 @@ dependencies {
 
 ### graphql-java schema transformation
 
-`graphql-java-support` produces a `graphql.schema.GraphQLSchema` by transforming your existing schema in accordance to the
-[federation specification](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/).
-It follows the `Builder` pattern.
+`graphql-java-support` produces a `graphql.schema.GraphQLSchema` by transforming your existing schema in accordance to
+the [federation specification](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/). It follows
+the `Builder` pattern.
 
 Start with `com.apollographql.federation.graphqljava.Federation.transform(…)`, which can receive either:
+
 - A `GraphQLSchema`;
 - A `TypeDefinitionRegistry`, optionally with a `RuntimeWiring`;
-- A String, Reader, or File declaring the schema using the [Schema Definition Language](https://www.apollographql.com/docs/apollo-server/essentials/schema/#schema-definition-language),
+- A String, Reader, or File declaring the schema using
+  the [Schema Definition Language](https://www.apollographql.com/docs/apollo-server/essentials/schema/#schema-definition-language),
   optionally with a `RuntimeWiring`;
 
 and returns a `SchemaTransformer`.
 
-If your schema does not contain any types annotated with the `@key` directive, nothing else is required.
-You can build a transformed `GraphQLSchema` with `SchemaTransformer#build()`, and confirm it exposes `query { _schema { sdl } }`.
+If your schema does not contain any types annotated with the `@key` directive, nothing else is required. You can build a
+transformed `GraphQLSchema` with `SchemaTransformer#build()`, and confirm it exposes `query { _schema { sdl } }`.
 
-Otherwise, all types annotated with `@key` will be part of the `_Entity` union type,
-and reachable through `query { _entities(representations: [Any!]!) { … } }`. Before calling `SchemaTransformer#build()`,
-you will also need to provide:
+Otherwise, all types annotated with `@key` will be part of the `_Entity` union type, and reachable
+through `query { _entities(representations: [Any!]!) { … } }`. Before calling `SchemaTransformer#build()`, you will also
+need to provide:
+
 - A `TypeResolver` for `_Entity` using `SchemaTransformer#resolveEntityType(TypeResolver)`;
 - A `DataFetcher` or `DataFetcherFactory` for `_entities`
   using `SchemaTransformer#fetchEntities(DataFetcher|DataFetcherFactory)`.
@@ -57,56 +62,53 @@ A minimal but complete example is available in
 
 ### Federated tracing
 
-To make your server generate performance traces and return them along with
-responses to the Apollo Gateway (which then can send them to Apollo Graph
-Manager), install the `FederatedTracingInstrumentation` into your `GraphQL`
-object:
+To make your server generate performance traces and return them along with responses to the Apollo Gateway (which then
+can send them to Apollo Graph Manager), install the `FederatedTracingInstrumentation` into your `GraphQL` object:
 
 ```java
 GraphQL graphql = GraphQL.newGraphQL(graphQLSchema)
-  .instrumentation(new FederatedTracingInstrumentation())
-  .build()
+        .instrumentation(new FederatedTracingInstrumentation())
+        .build();
 ```
 
-It is generally desired to only create traces for requests that actually come
-from Apollo Gateway, as they aren't helpful if you're connecting directly to
-your backend service for testing. In order for `FederatedTracingInstrumentation`
-to know if the request is coming from Gateway, you need to give it access to the
-HTTP request's headers, by making the `context` part of your `ExecutionInput`
-implement the `HTTPRequestHeaders` interface.  For example:
+It is generally desired to only create traces for requests that actually come from Apollo Gateway, as they aren't
+helpful if you're connecting directly to your backend service for testing. In order
+for `FederatedTracingInstrumentation` to know if the request is coming from Gateway, you need to give it access to the
+HTTP request's headers, by making the `context` part of your `ExecutionInput` implement the `HTTPRequestHeaders`
+interface. For example:
 
 ```java
 HTTPRequestHeaders context = new HTTPRequestHeaders() {
     @Override
-    public @Nullable String getHTTPRequestHeader(String caseInsensitiveHeaderName) {
+    public @Nullable
+    String getHTTPRequestHeader(String caseInsensitiveHeaderName) {
         return myIncomingHTTPRequest.getHeader(caseInsensitiveHeaderName);
     }
 };
 graphql.execute(ExecutionInput.newExecutionInput(queryString).context(context));
 ```
 
-Alternatively, if you are using libraries or frameworks whose `context` do not
-/ are not able to implement the `HTTPRequestHeaders` interface, you can construct
-the FederatedTracingInstrumentation using an Options object with a predicate that
-takes the `ExecutionInput` object and returns a boolean indicating whether a trace should be created for
-the request being processed.  For example:
+Alternatively, if you are using libraries or frameworks whose `context` do not / are not able to implement
+the `HTTPRequestHeaders` interface, you can construct the `FederatedTracingInstrumentation` using an `Options` object
+with a predicate that takes the `ExecutionInput` object and returns a boolean indicating whether a trace should be
+created for the request being processed. For example:
 
 ```java
 Options options = new Options(false, (ExecutionInput executionInput) -> {
-    // you are now able to interrogate your ExecutionInput and its context...
-    // ie: test for the existance of headers with a particular value
-
+    // Apollo Gateway indicates that a trace must be computed when the HTTP header "apollo-federation-include-trace"
+    // exists and has the value "ftv1".
+    //
+    // It is expected for you to store the above information in some manner within ExecutionInput or its context, and
+    // for this function to extract that information and return whether the trace must be computed.
     if (executionInput.getContext() instanceof MySpecialExecutionContext) {
-        // Use whatever methods/values are within your context object to inspect headers 
-        // if header apollo-federation-include-trace exists and is set to ftv1 return true
         return FEDERATED_TRACING_HEADER_VALUE.equals(
-                ((MySpecialExecutionContext)executionInput.getContext()).getHeader(FEDERATED_TRACING_HEADER_NAME));
+                ((MySpecialExecutionContext) executionInput.getContext()).getHeader(FEDERATED_TRACING_HEADER_NAME));
     }
     return false;
 });
 
 GraphQL graphql = GraphQL
-                    .newGraphQL(graphQLSchema)
-                    .instrumentation(new FederatedTracingInstrumentation(options))
-                    .build();
+        .newGraphQL(graphQLSchema)
+        .instrumentation(new FederatedTracingInstrumentation(options))
+        .build();
 ```


### PR DESCRIPTION
This PR:
- Reflows the text in `README.md` to be more consistent.
- Reformats the Java code blocks in `README.md`.
- Clarifies the example for the federated tracing predicate.