### PR TITLE
Upgrade to graphql-java 17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,12 @@
         -->
         <skip.dependency.convergence>false</skip.dependency.convergence>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <graphql-java.version>16.1</graphql-java.version>
-        <graphql-java-kickstart.version>11.0.0</graphql-java-kickstart.version>
+        <graphql-java.version>17.1</graphql-java.version>
+        <graphql-java-extended-scalars.version>17.0</graphql-java-extended-scalars.version>
+        <graphql-java-kickstart.version>11.1.0</graphql-java-kickstart.version>
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
-        <junit.version>5.7.1</junit.version>
+        <junit.version>5.7.2</junit.version>
         <!-- Can't upgrade to 3.2.X until https://issues.apache.org/jira/browse/MDEP-753 is fixed. -->
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <!--
@@ -93,9 +94,9 @@
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
         <spotless.version>2.12.2</spotless.version>
-        <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
+        <spring-boot.version>2.5.4</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -126,6 +127,12 @@
                 <groupId>com.graphql-java</groupId>
                 <artifactId>graphql-java</artifactId>
                 <version>${graphql-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.graphql-java</groupId>
+                <artifactId>graphql-java-extended-scalars</artifactId>
+                <version>${graphql-java-extended-scalars.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         -->
         <skip.dependency.convergence>false</skip.dependency.convergence>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <graphql-java.version>17.1</graphql-java.version>
+        <graphql-java.version>17.2</graphql-java.version>
         <graphql-java-extended-scalars.version>17.0</graphql-java-extended-scalars.version>
         <graphql-java-kickstart.version>11.1.0</graphql-java-kickstart.version>
         <java.version>1.8</java.version>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <!-- Note that spring-example wasn't designed to be imported, so this is fine. -->
         <skip.dependency.convergence>true</skip.dependency.convergence>
-        <fasterxml.jackson.version>2.12.0</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.12.4</fasterxml.jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>
-                <version>5.2.11.RELEASE</version>
+                <version>5.3.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This commit upgrades the framework to [graphql-java 17.0](https://github.com/graphql-java/graphql-java/releases/tag/v17.0).

Required changes.

* Upgrade to graphql-java-tools 11.1.0, it now supports graphql-java 17.0
* Include graphql-java-extended-scalars since it was moved out of graphql-java.
* Upgrade to Spring Boot 2.4.5 due that graphql-java-kickstarter requires a min of 2.4.5. If we don't do this the MVN Enforcer Plugin will fail the build. Same case for junit, log4j, and spring-aop.