### PR TITLE
**/pom.xml: Add Maven Enforcer and Dependency plugins, and tidy up build system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,30 @@
-version: 2
+version: 2.1
 jobs:
-  build:
+  Java SE 8 Maven Verify:
     docker:
-      - image: circleci/openjdk:8
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - run:
-          name: Concatenate all pom.xml
+          name: Generate cache checksum
           command: cat pom.xml */pom.xml > allpoms.xml
       - restore_cache:
-          key: cache-{{ checksum "allpoms.xml" }}
+          key: maven-{{ checksum "allpoms.xml" }}
       - run:
           name: Install dependencies
-          # https://issues.apache.org/jira/browse/MDEP-568 for --fail-never
-          command: ./mvnw --settings settings.xml --batch-mode --fail-never dependency:go-offline -DexcludeGroupIds=com.apollographql.federation
+          command: ./mvnw --settings settings-ci.xml --batch-mode dependency:go-offline
       - save_cache:
           paths:
-            - ~/.m2
-          key: cache-{{ checksum "allpoms.xml" }}
+            - ~/.m2/
+          key: maven-{{ checksum "allpoms.xml" }}
       - run:
-          name: Build, install, test
-          command: ./mvnw --settings settings.xml --batch-mode install test -Dgpg.skip
+          name: Compile, test, verify
+          command: ./mvnw --settings settings-ci.xml --batch-mode verify
       - run:
-          name: Save test results
+          name: Collect test results
           command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+            mkdir -p ~/test-results/JUnit/
+            find . -type f -regex '.*/target/surefire-reports/.*\.xml' -exec cp {} ~/test-results/JUnit/ \;
           when: always
       - store_test_results:
           path: ~/test-results
@@ -34,4 +33,4 @@ workflows:
   version: 2
   Build and Test:
     jobs:
-      - build
+      - Java SE 8 Maven Verify

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -20,7 +20,7 @@ import java.util.Properties;
 
 public class MavenWrapperDownloader {
 
-    private static final String WRAPPER_VERSION = "0.5.5";
+    private static final String WRAPPER_VERSION = "0.5.6";
     /**
      * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
      */

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,14 +15,15 @@
 - Delete the `private.key` file.
 
 ## For each release
-- Start a branch `release-VERSION`
-- Update RELEASE_NOTES.md
-- Edit all instances of (next version)-SNAPSHOT in all pom.xml files to be the desired version
-- Edit version in Gradle section of README.md
-- Push branch, open PR, wait for CI to pass
-- Run `SONATYPE_USERNAME=username SONATYPE_PASSWORD=password ./mvnw --settings settings.xml clean deploy`
-- A prompt will appear asking you for the GPG passphrase; get this from 1Password
+- Start a branch `release-VERSION`.
+- Update RELEASE_NOTES.md.
+- Edit all instances of (next version)-SNAPSHOT in all pom.xml files to be the desired version.
+- Edit version in Gradle section of README.md.
+- Push branch, open PR, wait for CI to pass.
+- Ensure you are using the latest Zulu build of OpenJDK 8.
+- Run `SONATYPE_USERNAME=username SONATYPE_PASSWORD=password ./mvnw --settings settings-release.xml clean deploy`
+- A prompt will appear asking you for the GPG passphrase; get this from 1Password.
 - Run `git tag vVERSION && git push origin vVERSION`
-- Edit all instances of the version in all pom.xml files to be the next patch release plus `-SNAPSHOT`
-- Push branch again
-- Merge PR
+- Edit all instances of the version in all pom.xml files to be the next patch release plus the `-SNAPSHOT` suffix.
+- Push branch again.
+- Merge PR.

--- a/graphql-java-support/pom.xml
+++ b/graphql-java-support/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
+# Maven Start Up Batch script
 #
 # Required ENV vars:
 # ------------------
@@ -212,9 +212,9 @@ else
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
     if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     else
-      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
@@ -246,7 +246,7 @@ else
         else
             curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
         fi
-        
+
     else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -18,7 +18,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Maven2 Start Up Batch script
+@REM Maven Start Up Batch script
 @REM
 @REM Required ENV vars:
 @REM JAVA_HOME - location of a JDK home dir
@@ -26,7 +26,7 @@
 @REM Optional ENV vars
 @REM M2_HOME - location of maven2's installed home dir
 @REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
 @REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
 @REM     e.g. to debug Maven itself, use
 @REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
@@ -120,7 +120,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
@@ -134,7 +134,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <skip.ci>true</skip.ci>
+        <skip.release>true</skip.release>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <graphql-java.version>16.1</graphql-java.version>
         <graphql-java-kickstart.version>11.0.0</graphql-java-kickstart.version>
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
         <junit.version>5.7.1</junit.version>
+        <!-- Can't use extra-enforcer-rules until https://github.com/mojohaus/extra-enforcer-rules/issues/131 is fixed -->
+        <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
@@ -191,6 +195,70 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-always</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <banDuplicatePomDependencyVersions/>
+                                    <dependencyConvergence/>
+                                    <requireReleaseDeps>
+                                        <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                        <excludes>com.apollographql.federation:*</excludes>
+                                    </requireReleaseDeps>
+                                    <requireUpperBoundDeps/>
+                                </rules>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>enforce-ci</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${skip.ci}</skip>
+                                <rules>
+                                    <requireActiveProfile>
+                                        <profiles>ci,release</profiles>
+                                        <all>false</all>
+                                    </requireActiveProfile>
+                                    <requireJavaVendor>
+                                        <includes>
+                                            <include>AdoptOpenJDK</include>
+                                            <include>Azul Systems, Inc.</include>
+                                        </includes>
+                                    </requireJavaVendor>
+                                    <requireJavaVersion>
+                                        <version>[1.8.0-282,1.9)</version>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>enforce-release</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${skip.release}</skip>
+                                <rules>
+                                    <requireActiveProfile>
+                                        <profiles>release</profiles>
+                                    </requireActiveProfile>
+                                    <requireReleaseVersion/>
+                                    <requireReleaseDeps/>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>${maven-gpg-plugin.version}</version>
                     <executions>
@@ -201,6 +269,11 @@
                             </goals>
                         </execution>
                     </executions>
+                    <configuration>
+                        <skip>${skip.release}</skip>
+                        <!-- This is the public fingerprint for the Apollo PGP key -->
+                        <keyname>5A446C80C27E095353CF3969F165A96372E61948</keyname>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
@@ -208,6 +281,7 @@
                     <version>${nexus-staging-maven-plugin.version}</version>
                     <extensions>true</extensions>
                     <configuration>
+                        <skipNexusStagingDeployMojo>${skip.release}</skipNexusStagingDeployMojo>
                         <serverId>sonatype-ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
@@ -223,6 +297,10 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
             <plugin>
@@ -231,4 +309,21 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <properties>
+                <skip.ci>false</skip.ci>
+                <skip.release>true</skip.release>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skip.ci>false</skip.ci>
+                <skip.release>false</skip.release>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,18 @@
                             </goals>
                             <configuration>
                                 <failOnWarning>true</failOnWarning>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <!-- We use an aggregator artifact here, which looks unused to static analysis -->
+                                    <ignoredUnusedDeclaredDependency>
+                                        org.junit.jupiter:junit-jupiter
+                                    </ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                                <ignoredUsedUndeclaredDependencies>
+                                    <!-- Normally we should declare used transitive dependencies, but this it's in an aggregator artifact -->
+                                    <ignoredUsedUndeclaredDependency>
+                                        org.junit.jupiter:junit-jupiter-api
+                                    </ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
                             </configuration>
                         </execution>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,11 @@
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
         <junit.version>5.7.1</junit.version>
-        <!-- Can't upgrade to 3.2.X until https://issues.apache.org/jira/browse/MDEP-753 is fixed -->
+        <!-- Can't upgrade to 3.2.X until https://issues.apache.org/jira/browse/MDEP-753 is fixed. -->
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-        <!-- Can't use extra-enforcer-rules until https://github.com/mojohaus/extra-enforcer-rules/issues/131 is fixed -->
+        <!--
+        Can't use extra-enforcer-rules until https://github.com/mojohaus/extra-enforcer-rules/issues/131 is fixed.
+        -->
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
@@ -199,7 +201,7 @@
                     </executions>
                     <configuration>
                         <notimestamp>true</notimestamp>
-                        <!-- protobuf generated java classes are missing various tags, so disable 'missing' -->
+                        <!-- protobuf generated java classes are missing various tags, so disable 'missing'. -->
                         <doclint>all,-missing</doclint>
                     </configuration>
                 </plugin>
@@ -221,13 +223,16 @@
                             <configuration>
                                 <failOnWarning>true</failOnWarning>
                                 <ignoredUnusedDeclaredDependencies>
-                                    <!-- We use an aggregator artifact here, which looks unused to static analysis -->
+                                    <!-- We use an aggregator artifact here, which looks unused to static analysis. -->
                                     <ignoredUnusedDeclaredDependency>
                                         org.junit.jupiter:junit-jupiter
                                     </ignoredUnusedDeclaredDependency>
                                 </ignoredUnusedDeclaredDependencies>
                                 <ignoredUsedUndeclaredDependencies>
-                                    <!-- Normally we should declare used transitive dependencies, but this it's in an aggregator artifact -->
+                                    <!--
+                                    Normally we should declare used transitive dependencies, but it's in an aggregator
+                                    artifact, so it's fine here.
+                                    -->
                                     <ignoredUsedUndeclaredDependency>
                                         org.junit.jupiter:junit-jupiter-api
                                     </ignoredUsedUndeclaredDependency>
@@ -341,7 +346,7 @@
                     </executions>
                     <configuration>
                         <skip>${skip.release}</skip>
-                        <!-- This is the public fingerprint for the Apollo PGP key -->
+                        <!-- This is the public fingerprint for the Apollo PGP key. -->
                         <keyname>5A446C80C27E095353CF3969F165A96372E61948</keyname>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
         <junit.version>5.7.1</junit.version>
+        <!-- Can't upgrade to 3.2.X until https://issues.apache.org/jira/browse/MDEP-753 is fixed -->
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <!-- Can't use extra-enforcer-rules until https://github.com/mojohaus/extra-enforcer-rules/issues/131 is fixed -->
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -195,6 +197,38 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>analyze-dep-mgt</id>
+                            <goals>
+                                <goal>analyze-dep-mgt</goal>
+                            </goals>
+                            <configuration>
+                                <failBuild>true</failBuild>
+                                <ignoreDirect>false</ignoreDirect>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>analyze-duplicate</id>
+                            <goals>
+                                <goal>analyze-duplicate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${maven-enforcer-plugin.version}</version>
                     <executions>
@@ -295,6 +329,10 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-actuator</artifactId>
                 <version>${spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,9 @@
                                     <requireJavaVersion>
                                         <version>[1.8.0-282,1.9)</version>
                                     </requireJavaVersion>
+                                    <requireMavenVersion>
+                                        <version>[3.8.1,)</version>
+                                    </requireMavenVersion>
                                 </rules>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,19 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <skip.ci>true</skip.ci>
         <skip.release>true</skip.release>
+        <!--
+        Dependency convergence should only be skipped for projects that aren't expected to be imported. Otherwise, if
+        convergence fails, use Maven <exclusions> to enforce that a single transitive dependency version is exposed.
+
+        Note that Maven <dependencyManagement> is not transitive, so while it can enforce transitive dependency versions
+        during project builds, it won't enforce them for dependents on the project. Dependents will instead only see the
+        versions of the dependencies as declared by their direct dependents, and will ignore <dependencyManagement>
+        entries that try to enforce a transitive dependency version. This might be fine for dependents using Gradle
+        (which picks the highest of all transitive dependency versions), but for dependents using Maven, this can lead
+        to runtime errors, since Maven uses "nearest first" for transitive dependencies which can pick versions that are
+        too small. More info at https://issues.apache.org/jira/browse/MNG-5761 .
+        -->
+        <skip.dependency.convergence>false</skip.dependency.convergence>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <graphql-java.version>16.1</graphql-java.version>
         <graphql-java-kickstart.version>11.0.0</graphql-java-kickstart.version>
@@ -252,12 +265,23 @@
                             <configuration>
                                 <rules>
                                     <banDuplicatePomDependencyVersions/>
-                                    <dependencyConvergence/>
                                     <requireReleaseDeps>
                                         <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
                                         <excludes>com.apollographql.federation:*</excludes>
                                     </requireReleaseDeps>
                                     <requireUpperBoundDeps/>
+                                </rules>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>enforce-dependency-convergence</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${skip.dependency.convergence}</skip>
+                                <rules>
+                                    <dependencyConvergence/>
                                 </rules>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spring-boot.version>2.3.6.RELEASE</spring-boot.version>
@@ -164,10 +164,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
-                    <configuration>
-                        <!-- Workaround from https://stackoverflow.com/questions/50661648/spring-boot-fails-to-run-maven-surefire-plugin-classnotfoundexception-org-apache/50661649#50661649 -->
-                        <useSystemClassLoader>false</useSystemClassLoader>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/settings-ci.xml
+++ b/settings-ci.xml
@@ -2,11 +2,7 @@
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <servers>
-        <server>
-            <id>sonatype-ossrh</id>
-            <username>${env.SONATYPE_USERNAME}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
-        </server>
-    </servers>
+    <activeProfiles>
+        <activeProfile>ci</activeProfile>
+    </activeProfiles>
 </settings>

--- a/settings-release.xml
+++ b/settings-release.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>sonatype-ossrh</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+    <activeProfiles>
+        <activeProfile>release</activeProfile>
+    </activeProfiles>
+</settings>

--- a/settings.xml
+++ b/settings.xml
@@ -9,15 +9,4 @@
             <password>${env.SONATYPE_PASSWORD}</password>
         </server>
     </servers>
-    <profiles>
-        <profile>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <!-- This is the public fingerprint for the Apollo PGP key -->
-                <gpg.keyname>5A446C80C27E095353CF3969F165A96372E61948</gpg.keyname>
-            </properties>
-        </profile>
-    </profiles>
 </settings>

--- a/spring-example/README.md
+++ b/spring-example/README.md
@@ -3,7 +3,7 @@ This Spring Boot application contains examples for both a microservice using sta
 To run the standard `graphql-java` example, `cd` to the root of this project, then...
 ```
 ## compile and install project including example and dependencies
-mvn install -Dgpg.skip
+mvn install
 ## start local webserver on 9000
 mvn -pl spring-example spring-boot:run
 ```

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -18,13 +18,57 @@
     <properties>
         <!-- Note that spring-example wasn't designed to be imported, so this is fine. -->
         <skip.dependency.convergence>true</skip.dependency.convergence>
+        <fasterxml.jackson.version>2.12.0</fasterxml.jackson.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            The following dependencies exist solely to override Maven's default "nearest first" strategy for transitive
+            dependency version conflict resolution. Note that as stated in the parent POM, we would normally use Maven
+            <exclusions> instead to get transitivity, but since spring-example isn't designed to be imported, it's fine
+            (and a lot less work in this case) to just add dependencies to <dependencyManagement>.
+            -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>5.2.11.RELEASE</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.apollographql.federation</groupId>
             <artifactId>federation-graphql-java-support</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -77,6 +121,64 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <ignoredUnusedDeclaredDependencies>
+                                <!--
+                                We use aggregator artifacts here, which look unused to static analysis. Note that
+                                this means it's the maintainers' responsibility to know when these artifacts are unused
+                                and can be safely removed (check the starters' docs if you're unsure).
+                                -->
+                                <ignoredUnusedDeclaredDependency>
+                                    org.junit.jupiter:junit-jupiter
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    org.springframework.boot:spring-boot-starter-actuator
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    org.springframework.boot:spring-boot-starter-web
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    org.springframework.boot:spring-boot-starter-test
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    com.graphql-java-kickstart:graphql-spring-boot-starter
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    com.graphql-java-kickstart:graphiql-spring-boot-starter
+                                </ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>
+                                    com.graphql-java-kickstart:graphql-spring-boot-starter-test
+                                </ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                            <ignoredUsedUndeclaredDependencies>
+                                <!--
+                                Normally we should declare used transitive dependencies, but these are in aggregator
+                                artifacts, so it's fine here. We use * for artifacts because realistically maintainers
+                                aren't going to check whether every transitive dependency exists in the aggregator
+                                artifact. This means it's the maintainers' responsibility to ensure used artifacts at
+                                these group IDs are provided by the above aggregator artifacts.
+                                -->
+                                <ignoredUsedUndeclaredDependency>
+                                    org.junit.jupiter:junit-jupiter-api
+                                </ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:*</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>
+                                    org.springframework.boot:*
+                                </ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>
+                                    com.graphql-java-kickstart:*
+                                </ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -15,6 +15,11 @@
     <name>federation-spring-example</name>
     <description>Spring Boot example of federation-graphql-java-support usage</description>
 
+    <properties>
+        <!-- Note that spring-example wasn't designed to be imported, so this is fine -->
+        <skip.dependency.convergence>true</skip.dependency.convergence>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.apollographql.federation</groupId>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -16,7 +16,7 @@
     <description>Spring Boot example of federation-graphql-java-support usage</description>
 
     <properties>
-        <!-- Note that spring-example wasn't designed to be imported, so this is fine -->
+        <!-- Note that spring-example wasn't designed to be imported, so this is fine. -->
         <skip.dependency.convergence>true</skip.dependency.convergence>
     </properties>
 

--- a/spring-example/src/test/java/com/apollographql/federation/springexample/GraphQLJavaAppTest.java
+++ b/spring-example/src/test/java/com/apollographql/federation/springexample/GraphQLJavaAppTest.java
@@ -2,15 +2,15 @@ package com.apollographql.federation.springexample;
 
 import com.graphql.spring.boot.test.GraphQLTest;
 import com.graphql.spring.boot.test.GraphQLTestTemplate;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @GraphQLTest(profiles = "graphql-java")
 @Import(App.class)
 public class GraphQLJavaAppTest extends BaseAppTest {

--- a/spring-example/src/test/java/com/apollographql/federation/springexample/GraphQLJavaToolsAppTest.java
+++ b/spring-example/src/test/java/com/apollographql/federation/springexample/GraphQLJavaToolsAppTest.java
@@ -2,15 +2,15 @@ package com.apollographql.federation.springexample;
 
 import com.graphql.spring.boot.test.GraphQLTest;
 import com.graphql.spring.boot.test.GraphQLTestTemplate;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @GraphQLTest(profiles = "graphql-java-tools")
 @Import(App.class)
 public class GraphQLJavaToolsAppTest extends BaseAppTest {


### PR DESCRIPTION
This PR has a lot of build system changes/updates. Specifically, this PR:
- Creates three Maven profiles:
  - The default (no profile), which normal users and contributors are expected to run.
  - The CI profile, which adds some extra checks.
  - The release profile, which adds some extra checks on top of CI.
- Sets GPG signing and the deploy goal to be skipped unless running the release profile.
- Adds the Maven Enforcer plugin.
  - For every build, this is configured to:
    - Prevent duplicate dependencies from appearing in POMs.
    - For artifacts not in this repo, require we use the release version of those dependencies.
    - Require that the dependency version chosen by Maven for dependency version conflicts is the upper bound of all such dependency versions in conflict.
    - For libraries (everything except `spring-example`), require that all non-excluded dependency versions are equal. (The idea being that libraries should only appear to require a single version of an artifact, and that we should manage dependency conflicts using Maven `<exclusions>`.)
  - For CI and release builds, this is additionally configured to:
    - Require the use of Zulu or AdoptOpenJDK builds of OpenJDK 8.
    - Require the use of at least Maven 3.8.1.
  - For release builds, this is additionally configured to:
    - Require that all artifact versions are release versions.
    - Require that all dependencies (including ones in this repo) are release versions.
- Adds the Maven Dependency plugin.
  - For every build, this is configured to:
    - Prevent duplicate dependencies from appearing in POMs (both `<dependencies>` and `<dependencyManagement>`).
    - Prevent the use of undeclared transitive dependencies, with manual exceptions for aggregator artifacts.
    - Prevent the use of unused dependencies, with manual exceptions for aggregator artifacts.
    - Fail when `<dependencyManagement>` is not honored or is overridden.
- Fix bugs noticed by the above.
  - We were previously using JUnit 4 tests instead of JUnit 5 tests in `spring-example`.
  - We were previously using undeclared transitive dependencies of `graphql-java` and `annotations` in `spring-example`.
  - There were a number of dependency version conflicts that were being resolved to too low a version, which we fixed in this case by using `<dependencyManagement>` (note that libraries should fix this via `<exclusions>`).
- Bump Maven Surefire plugin to `3.0.0-M5`.
  - This allows us to remove a buggy hack around class loaders we previously employed.
- Bump Maven wrapper to latest and its Maven version to `3.8.1`.
- Create a `slf4j-api` entry in `<dependencyManagement>`.
- Update the CircleCI config.
  - The settings file to use is now `settings-ci.xml`.
  - Change Maven command to be `maven verify` instead of `maven install test` (`test` is run during `install`, and the `install:install` goal isn't really necessary here so we use `verify` instead).
  - Remove `-DexcludeGroupIds=com.apollographql.federation` when running `dependency:go-offline`, as it's not needed when running from the parent POM directory.
  - Bump image name to `cimg/openjdk:8.0`.
  - Bump config file version to `2.1`.
  - Some naming/phrasing changes.
- Update `spring-example` docs.
  - Users no longer have to use `-Dgpg.skip`.
- Update `RELEASING.md` docs.
  - The settings file to use is now `settings-release.xml`.
  - Maintainers must use a Zulu build of OpenJDK 8 for release. 