### PR TITLE
spring-example: Change README to mention that users can query their subgraphs with GraphiQL

### DIFF
--- a/spring-example/README.md
+++ b/spring-example/README.md
@@ -16,3 +16,4 @@ Now you can query your local graph:
 ## e.g.
 curl -X POST  -H "Content-Type: application/json" --data '{"query":"{__schema{types{name}}}"}' "http://localhost:9000/graphql"
 ```
+You can also query your local graph with GraphiQL at http://localhost:9000/graphiql .


### PR DESCRIPTION
The currrent `README.md` for `spring-example` doesn't mention that subgraphs can be queried with GraphiQL. This PR updates the `README.md` to indicate this.