### PR TITLE
Add a helper script for releases

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,15 +15,13 @@
 - Delete the `private.key` file.
 
 ## For each release
-- Start a branch `release-VERSION`.
-- Update RELEASE_NOTES.md.
-- Edit all instances of (next version)-SNAPSHOT in all pom.xml files to be the desired version.
-- Edit version in Gradle section of README.md.
-- Push branch, open PR, wait for CI to pass.
-- Ensure you are using the latest Zulu build of OpenJDK 8.
-- Run `SONATYPE_USERNAME=username SONATYPE_PASSWORD=password ./mvnw --settings settings-release.xml clean deploy`
-- A prompt will appear asking you for the GPG passphrase; get this from 1Password.
-- Run `git tag vVERSION && git push origin vVERSION`
-- Edit all instances of the version in all pom.xml files to be the next patch release plus the `-SNAPSHOT` suffix.
-- Push branch again.
-- Merge PR.
+1. Start a branch `release-VERSION`.
+1. Update RELEASE_NOTES.md.
+1. Run `tag.main.kts $version` to update all versions in pom files/README and create a tag.
+1. Push branch, open PR, wait for CI to pass.
+1. Ensure you are using the latest Zulu build of OpenJDK 8.
+1. Checkout the tag created in step 3: `get checkout v$version`
+1. Run `SONATYPE_USERNAME=username SONATYPE_PASSWORD=password ./mvnw --settings settings-release.xml clean deploy`
+1. A prompt will appear asking you for the GPG passphrase; get this from 1Password.
+1. If everything went well, merge the PR
+1. And push the tag: `git push origin vVERSION`

--- a/tag.main.kts
+++ b/tag.main.kts
@@ -1,0 +1,121 @@
+#!/usr/bin/env kotlin
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * A script to run locally in order to make a release.
+ *
+ * You need kotlin installed on your machine
+ */
+
+val arguments = args.toMutableList()
+
+val force = arguments.remove("-f")
+
+if (!force) {
+  if (runCommand("git", "status", "--porcelain").isNotEmpty()) {
+    println("Your git repo is not clean. Make sur to stash or commit your changes before making a release")
+    exitProcess(1)
+  }
+}
+
+check(getCurrentVersion().endsWith("-SNAPSHOT")) {
+  "Version '${getCurrentVersion()} is not a -SNAPSHOT, check your working directory"
+}
+
+check(arguments.size == 1) {
+  "tag.main.kts [version to tag]"
+}
+val tagVersion = arguments[0]
+val nextSnapshot = getNextSnapshot(tagVersion)
+
+
+while (true) {
+  println("Current version is '${getCurrentVersion()}'.")
+  println("Tag '$tagVersion' and bump to $nextSnapshot [y/n]?")
+
+  when (readLine()!!.trim()) {
+    "y" -> break
+    "n" -> {
+      println("Aborting.")
+      exitProcess(1)
+    }
+  }
+}
+
+setCurrentVersion(tagVersion)
+setReadmeVersion(tagVersion)
+runCommand("git", "commit", "-a", "-m", "release $tagVersion")
+runCommand("git", "tag", "v$tagVersion")
+
+setCurrentVersion(nextSnapshot)
+runCommand("git", "commit", "-a", "-m", "version is now $nextSnapshot")
+
+println("Everything is done. Verify everything is ok and type `git push origin main` to trigger the new version.")
+
+fun runCommand(vararg args: String): String {
+  val builder = ProcessBuilder(*args)
+    .redirectError(ProcessBuilder.Redirect.INHERIT)
+
+  val process = builder.start()
+  val ret = process.waitFor()
+
+  val output = process.inputStream.bufferedReader().readText()
+  if (ret != 0) {
+    throw java.lang.Exception("command ${args.joinToString(" ")} failed:\n$output")
+  }
+
+  return output
+}
+
+fun File.replace(pattern: String, replacement: String) {
+  writeText(readText().replace(Regex(pattern, RegexOption.DOT_MATCHES_ALL), replacement))
+}
+
+fun setReadmeVersion(version: String) {
+  File("README.md").replace(
+    pattern = "implementation 'com.apollographql.federation:federation-graphql-java-support:[^']*'",
+    replacement = "implementation 'com.apollographql.federation:federation-graphql-java-support:$version'",
+  )
+}
+
+fun setCurrentVersion(version: String) {
+  File("graphql-java-support/pom.xml")
+    .replace(
+      pattern = "<artifactId>federation-parent</artifactId>\n        <version>[^<]*</version>",
+      replacement = "<artifactId>federation-parent</artifactId>\n        <version>$version</version>",
+    )
+  File("graphql-java-support-api/pom.xml")
+    .replace(
+      pattern = "<artifactId>federation-parent</artifactId>\n        <version>[^<]*</version>",
+      replacement = "<artifactId>federation-parent</artifactId>\n        <version>$version</version>",
+    )
+  File("spring-example/pom.xml")
+    .replace(
+      pattern = "<artifactId>federation-parent</artifactId>\n        <version>[^<]*</version>",
+      replacement = "<artifactId>federation-parent</artifactId>\n        <version>$version</version>",
+    )
+  File("pom.xml")
+    .replace(
+      pattern = "<artifactId>federation-parent</artifactId>\n    <version>[^<]*</version>",
+      replacement = "<artifactId>federation-parent</artifactId>\n    <version>$version</version>",
+    )
+}
+
+fun getCurrentVersion(): String {
+  return Regex(".*<artifactId>federation-parent</artifactId>.    <version>([^<]*)</version>.*", RegexOption.DOT_MATCHES_ALL)
+    .matchEntire(File("pom.xml").readText())
+    ?.groupValues
+    ?.get(1) ?: error("Cannot find version")
+}
+
+
+fun getNextSnapshot(version: String): String {
+  check(!version.contains("SNAPSHOT")) {
+    "version should not contain 'SNAPSHOT': $version"
+  }
+  val components = version.split(".").toMutableList()
+  val part = components.removeLast().toIntOrNull() ?: error("Cannot find a number to bump in $version")
+  components.add("${part + 1}")
+  return components.joinToString(".") + "-SNAPSHOT"
+}


### PR DESCRIPTION
Add a `tag.main.kts $version` script that takes care of:

- setting versions in all pom.xml to `"$version"`
- setting the version in README.md
- creating a tag
- setting versions in all pom.xml to `"${version + 1}-SNAPSHOT"`

A next step would be to automate the release process completely by publishing releases and snapshots from CI (see also https://github.com/apollographql/federation-jvm/issues/131)