### PR TITLE
feat: cache-control calculation from directives

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 public final class _Entity {
   public static final String argumentName = "representations";
-  static final String typeName = "_Entity";
+  public static final String typeName = "_Entity";
   static final String fieldName = "_entities";
 
   private _Entity() {}

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
@@ -1,0 +1,339 @@
+package com.apollographql.federation.graphqljava.caching;
+
+import com.apollographql.federation.graphqljava._Entity;
+import graphql.ExecutionResult;
+import graphql.GraphQLContext;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.schema.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A GraphQL Java Instrumentation that computes a max age for an operation based on @cacheControl
+ * directives.
+ *
+ * <p>You can retrieve the "max-age=..." header value with a {@link graphql.GraphQLContext}: <code>
+ * String cacheControlHeader = CacheControlInstrumentation.cacheControlContext(context);
+ * </code>
+ *
+ * <p>See https://www.apollographql.com/docs/apollo-server/performance/caching/ and the original
+ * implementation at
+ * https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/plugin/cacheControl/index.ts
+ */
+public class CacheControlInstrumentation extends SimpleInstrumentation {
+  private final int defaultMaxAge;
+
+  private static final Object CONTEXT_KEY = new Object();
+  private static final String DIRECTIVE_NAME = "cacheControl";
+  private static final String MAX_AGE = "maxAge";
+  private static final String SCOPE = "scope";
+  private static final String INHERIT_MAX_AGE = "inheritMaxAge";
+
+  public CacheControlInstrumentation() {
+    this(0);
+  }
+
+  public CacheControlInstrumentation(int defaultMaxAge) {
+    this.defaultMaxAge = defaultMaxAge;
+  }
+
+  @Nullable
+  public static String cacheControlHeaderFromGraphQLContext(GraphQLContext context) {
+    return context.get(CONTEXT_KEY);
+  }
+
+  @Override
+  public InstrumentationState createState() {
+    return new CacheControlState();
+  }
+
+  @Override
+  public InstrumentationContext<ExecutionResult> beginExecution(
+      InstrumentationExecutionParameters parameters) {
+    return new InstrumentationContext<ExecutionResult>() {
+      @Override
+      public void onDispatched(CompletableFuture<ExecutionResult> completableFuture) {}
+
+      @Override
+      public void onCompleted(ExecutionResult executionResult, Throwable throwable) {
+        CacheControlState state = parameters.getInstrumentationState();
+
+        // Attach the policy to the context object
+        state
+            .overallPolicy
+            .maybeAsString()
+            .ifPresent(s -> parameters.getGraphQLContext().put(CONTEXT_KEY, s));
+      }
+    };
+  }
+
+  @Override
+  public InstrumentationContext<ExecutionResult> beginField(
+      InstrumentationFieldParameters parameters) {
+    CacheControlState state = parameters.getInstrumentationState();
+    CacheControlPolicy fieldPolicy = new CacheControlPolicy();
+    boolean inheritMaxAge = false;
+
+    GraphQLUnmodifiedType unwrappedFieldType =
+        GraphQLTypeUtil.unwrapAll(parameters.getExecutionStepInfo().getType());
+
+    // There's no way to set a cacheControl directive on the _entities field or
+    // the _Entity union in SDL. Instead, we can determine the possible concrete
+    // types from the representations arguments and select the most restrictive
+    // cache policy from those types.
+
+    if (unwrappedFieldType.getName().equals(_Entity.typeName)) {
+      Object representations = parameters.getExecutionStepInfo().getArgument(_Entity.argumentName);
+
+      if (representations instanceof List) {
+        typesFromEntitiesArgument(
+                representations, parameters.getExecutionContext().getGraphQLSchema())
+            .stream()
+            .map(
+                type ->
+                    CacheControlDirective.fromDirectiveContainer((GraphQLDirectiveContainer) type))
+            .filter(Optional::isPresent)
+            .forEach(directive -> fieldPolicy.restrict(directive.get()));
+      }
+    } else if (unwrappedFieldType instanceof GraphQLCompositeType
+        && unwrappedFieldType instanceof GraphQLDirectiveContainer) {
+
+      // Cache directive on the return type of this field if it's a composite type
+
+      Optional<CacheControlDirective> directive =
+          CacheControlDirective.fromDirectiveContainer(
+              (GraphQLDirectiveContainer) unwrappedFieldType);
+
+      if (directive.isPresent()) {
+        fieldPolicy.replace(directive.get());
+        inheritMaxAge = directive.get().getInheritMaxAge();
+      }
+    }
+
+    // Cache directive on the field itself
+
+    Optional<CacheControlDirective> fieldDirective =
+        CacheControlDirective.fromDirectiveContainer(parameters.getField());
+    if (fieldDirective.isPresent()) {
+      CacheControlDirective directive = fieldDirective.get();
+
+      // If inheritMaxAge is true, take note of that to avoid setting the
+      // default max age in the next step. This does allow setting the cache
+      // scope though.
+      //
+      // Note that specifying `@cacheControl(inheritMaxAge: true)` on a
+      // field whose return type defines a `maxAge` gives precedence to
+      // the type's `maxAge`. (Perhaps this should be some sort of
+      // error.)
+      if (directive.getInheritMaxAge() && !fieldPolicy.hasMaxAge()) {
+        inheritMaxAge = true;
+        fieldPolicy.replace(directive.getScope());
+      } else {
+        fieldPolicy.replace(directive);
+      }
+    }
+
+    // If this field returns a composite type or is a root field and
+    // we haven't seen an explicit maxAge argument, set the maxAge to 0
+    // (uncached) or the default if specified in the constructor.
+    // (Non-object fields by default are assumed to inherit their
+    // cacheability from their parents. But on the other hand, while
+    // root non-object fields can get explicit directives from their
+    // definition on the Query/Mutation object, if that doesn't exist
+    // then there's no parent field that would assign the default
+    // maxAge, so we do it here.)
+    //
+    // You can disable this on a non-root field by writing
+    // `@cacheControl(inheritMaxAge: true)` on it. If you do this,
+    // then its children will be treated like root paths, since there
+    // is no parent maxAge to inherit.
+
+    if (!fieldPolicy.hasMaxAge()
+        && ((unwrappedFieldType instanceof GraphQLCompositeType && !inheritMaxAge)
+            || parameters.getExecutionStepInfo().getPath().isRootPath())) {
+      fieldPolicy.restrict(defaultMaxAge);
+    }
+
+    state.overallPolicy.restrict(fieldPolicy);
+
+    return super.beginField(parameters);
+  }
+
+  enum CacheControlScope {
+    PUBLIC,
+    PRIVATE
+  }
+
+  private static class CacheControlState implements InstrumentationState {
+    public final CacheControlPolicy overallPolicy = new CacheControlPolicy();
+  }
+
+  private static class CacheControlPolicy {
+    @Nullable private Integer maxAge;
+    @Nullable private CacheControlScope scope = CacheControlScope.PUBLIC;
+
+    void restrict(CacheControlPolicy policy) {
+      if (policy.maxAge != null && (maxAge == null || policy.maxAge < maxAge)) {
+        this.maxAge = policy.maxAge;
+      }
+
+      if (policy.scope != null && (scope == null || !scope.equals(CacheControlScope.PRIVATE))) {
+        this.scope = policy.scope;
+      }
+    }
+
+    void restrict(CacheControlDirective directive) {
+      if (directive.maxAge != null && (maxAge == null || directive.maxAge < maxAge)) {
+        this.maxAge = directive.maxAge;
+      }
+
+      if (directive.scope != null && (scope == null || !scope.equals(CacheControlScope.PRIVATE))) {
+        this.scope = directive.scope;
+      }
+    }
+
+    void restrict(Integer maxAge) {
+      if (this.maxAge == null || maxAge < this.maxAge) {
+        this.maxAge = maxAge;
+      }
+    }
+
+    void replace(CacheControlDirective directive) {
+      if (directive.maxAge != null) {
+        this.maxAge = directive.maxAge;
+      }
+
+      if (directive.scope != null) {
+        this.scope = directive.scope;
+      }
+    }
+
+    void replace(@Nullable CacheControlScope scope) {
+      if (scope != null) {
+        this.scope = scope;
+      }
+    }
+
+    public Optional<String> maybeAsString() {
+      Integer maxAgeValue = maxAge == null ? 0 : maxAge;
+      if (maxAgeValue.equals(0)) {
+        return Optional.empty();
+      }
+
+      CacheControlScope scopeValue = scope == null ? CacheControlScope.PUBLIC : scope;
+      return Optional.of(
+          String.format("max-age=%d, %s", maxAgeValue, scopeValue.toString().toLowerCase()));
+    }
+
+    public boolean hasMaxAge() {
+      return maxAge != null;
+    }
+
+    public boolean hasScope() {
+      return scope != null;
+    }
+  }
+
+  private static class CacheControlDirective {
+    @Nullable private final Integer maxAge;
+    @Nullable private final CacheControlScope scope;
+    @Nullable private final Boolean inheritMaxAge;
+
+    public static Optional<CacheControlDirective> fromDirectiveContainer(
+        GraphQLDirectiveContainer container) {
+      GraphQLDirective directive = container.getDirective(DIRECTIVE_NAME);
+
+      if (directive == null) {
+        return Optional.empty();
+      }
+
+      Integer maxAge =
+          Optional.ofNullable(directive.getArgument(MAX_AGE))
+              .map(a -> GraphQLArgument.getArgumentValue(a))
+              .filter(v -> v instanceof Integer)
+              .map(Integer.class::cast)
+              .orElse(null);
+
+      CacheControlScope scope =
+          Optional.ofNullable(directive.getArgument(SCOPE))
+              .map(a -> GraphQLArgument.getArgumentValue(a))
+              .filter(v -> v instanceof String)
+              .map(s -> CacheControlScope.valueOf((String) s))
+              .orElse(null);
+
+      Boolean inheritMaxAge =
+          Optional.ofNullable(directive.getArgument(INHERIT_MAX_AGE))
+              .map(a -> GraphQLArgument.getArgumentValue(a))
+              .filter(v -> v instanceof Boolean)
+              .map(Boolean.class::cast)
+              .orElse(null);
+
+      return Optional.of(new CacheControlDirective(maxAge, scope, inheritMaxAge));
+    }
+
+    public CacheControlDirective(
+        @Nullable Integer maxAge,
+        @Nullable CacheControlScope scope,
+        @Nullable Boolean inheritMaxAge) {
+      this.maxAge = maxAge;
+      this.scope = scope;
+      this.inheritMaxAge = inheritMaxAge;
+    }
+
+    public boolean isRestricted() {
+      return maxAge != null || scope != null;
+    }
+
+    @Nullable
+    public Integer getMaxAge() {
+      return maxAge;
+    }
+
+    public boolean hasMaxAge() {
+      return maxAge != null;
+    }
+
+    @Nullable
+    public CacheControlScope getScope() {
+      return scope;
+    }
+
+    public boolean hasScope() {
+      return scope != null;
+    }
+
+    public Boolean getInheritMaxAge() {
+      return inheritMaxAge != null && inheritMaxAge;
+    }
+
+    public boolean hasInheritMaxAge() {
+      return inheritMaxAge != null;
+    }
+
+    public String toString() {
+      return String.format(
+          "@cacheControl(maxAge: %s, scope: %s, inheritMaxAge: %s)", maxAge, scope, inheritMaxAge);
+    }
+  }
+
+  static List<GraphQLType> typesFromEntitiesArgument(Object representations, GraphQLSchema schema) {
+    if (representations instanceof List) {
+      return ((List<?>) representations)
+          .stream()
+              .filter(rep -> rep instanceof Map<?, ?>)
+              .map(rep -> ((Map<?, ?>) rep).get("__typename"))
+              .map(Object::toString)
+              .distinct()
+              .map(schema::getType)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+    }
+    return new ArrayList<>();
+  }
+}

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/CacheControlInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/CacheControlInstrumentationTest.java
@@ -1,0 +1,380 @@
+package com.apollographql.federation.graphqljava;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.apollographql.federation.graphqljava.caching.CacheControlInstrumentation;
+import graphql.ExecutionInput;
+import graphql.GraphQL;
+import graphql.GraphQLContext;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+public class CacheControlInstrumentationTest {
+  private static final String DIRECTIVE_DEF =
+      "enum CacheControlScope { PUBLIC PRIVATE }\n"
+          + "directive @cacheControl(maxAge: Int scope: CacheControlScope inheritMaxAge: Boolean) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION\n";
+
+  static GraphQL makeExecutor(String sdl, int defaultMaxAge) {
+    TypeDefinitionRegistry typeDefs = new SchemaParser().parse(DIRECTIVE_DEF + sdl);
+
+    RuntimeWiring resolvers =
+        RuntimeWiring.newRuntimeWiring().wiringFactory(new WiringFactoryImpl()).build();
+
+    GraphQLSchema schema =
+        Federation.transform(typeDefs, resolvers)
+            .fetchEntities(env -> env.<List<Map<String, Object>>>getArgument(_Entity.argumentName))
+            .resolveEntityType(env -> env.getSchema().getObjectType("Product"))
+            .build();
+
+    return GraphQL.newGraphQL(schema)
+        .instrumentation(new CacheControlInstrumentation(defaultMaxAge))
+        .build();
+  }
+
+  static @Nullable String execute(String schema, String query) {
+    return execute(schema, query, 0, new HashMap<>());
+  }
+
+  static @Nullable String execute(String schema, String query, int defaultMaxAge) {
+    return execute(schema, query, defaultMaxAge, new HashMap<>());
+  }
+
+  static @Nullable String execute(
+      String schema, String query, int defaultMaxAge, Map<String, Object> variables) {
+    GraphQL graphql = makeExecutor(schema, defaultMaxAge);
+
+    ExecutionInput input =
+        ExecutionInput.newExecutionInput().query(query).variables(variables).build();
+    Map<String, Object> result = graphql.execute(input).toSpecification();
+
+    assertNull(result.get("errors"), "response contains errors");
+
+    GraphQLContext context = input.getGraphQLContext();
+    return CacheControlInstrumentation.cacheControlHeaderFromGraphQLContext(context);
+  }
+
+  static class WiringFactoryImpl implements WiringFactory {
+    @Override
+    public boolean providesDataFetcher(FieldWiringEnvironment environment) {
+      return true;
+    }
+
+    @Override
+    public DataFetcher<?> getDataFetcher(FieldWiringEnvironment environment) {
+      if (environment.getFieldType() instanceof GraphQLList) {
+        return (env) -> {
+          ArrayList<Object> objects = new ArrayList<>();
+          objects.add(new Object());
+          return objects;
+        };
+      }
+      if (environment.getFieldType() instanceof GraphQLObjectType) {
+        return (env) -> new Object();
+      }
+      return (env) -> "hello";
+    }
+  }
+
+  @Test
+  void noHints() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid"
+            + "}"
+            + ""
+            + "type Droid {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertNull(execute(schema, query));
+  }
+
+  @Test
+  void noHintsTopLevel() {
+    String schema = "type Query { name: String }";
+    String query = "{ name }";
+    assertNull(execute(schema, query));
+  }
+
+  @Test
+  void defaultMaxAge() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid"
+            + "}"
+            + ""
+            + "type Droid {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=10, public", execute(schema, query, 10));
+  }
+
+  @Test
+  void hintOnField() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid @cacheControl(maxAge: 60)"
+            + "}"
+            + ""
+            + "type Droid {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=60, public", execute(schema, query));
+  }
+
+  @Test
+  void hintOnReturnType() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid"
+            + "}"
+            + ""
+            + "type Droid @cacheControl(maxAge: 60) {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=60, public", execute(schema, query));
+  }
+
+  @Test
+  void hintOnReturnTypeList() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): [Droid]"
+            + "}"
+            + ""
+            + "type Droid @cacheControl(maxAge: 60) {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=60, public", execute(schema, query));
+  }
+
+  @Test
+  void hintOnReturnTypeExtension() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid"
+            + "}"
+            + ""
+            + "type Droid {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}"
+            + ""
+            + "extend type Droid @cacheControl(maxAge: 60)";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=60, public", execute(schema, query));
+  }
+
+  @Test
+  void overrideDefaultMaxAge() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid"
+            + "}"
+            + ""
+            + "type Droid @cacheControl(maxAge: 0) {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertNull(execute(schema, query, 10));
+  }
+
+  @Test
+  void hintOnFieldOverrideMaxAgeHintOnReturnType() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid @cacheControl(maxAge: 120)"
+            + "}"
+            + ""
+            + "type Droid @cacheControl(maxAge: 60) {"
+            + "  id: ID!"
+            + "  name: String!"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=120, public", execute(schema, query));
+  }
+
+  @Test
+  void scopeHintOnReturnType() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid @cacheControl(maxAge: 120)"
+            + "}"
+            + ""
+            + "type Droid @cacheControl(maxAge: 60, scope: PRIVATE) {"
+            + "  id: ID!"
+            + "  name: String!"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=120, private", execute(schema, query));
+  }
+
+  @Test
+  void privateOnFieldOverridesPublicOnType() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid @cacheControl(scope: PRIVATE)"
+            + "}"
+            + ""
+            + "type Droid @cacheControl(maxAge: 60, scope: PUBLIC) {"
+            + "  id: ID!"
+            + "  name: String!"
+            + "}";
+    String query = "{ droid(id: 2001) { name } }";
+    assertEquals("max-age=60, private", execute(schema, query));
+  }
+
+  @Test
+  void inheritMaxAge() {
+    String schema =
+        "type Query {\n"
+            + "  topLevel: DroidQuery @cacheControl(maxAge: 1000)\n"
+            + "}\n"
+            + "\n"
+            + "type DroidQuery {\n"
+            + "  droid: Droid @cacheControl(inheritMaxAge: true)\n"
+            + "  droids: [Droid] @cacheControl(inheritMaxAge: true)\n"
+            + "}\n"
+            + "\n"
+            + "type Droid {\n"
+            + "  uncachedField: Droid\n"
+            + "  scalarField: String\n"
+            + "  cachedField: String @cacheControl(maxAge: 30)\n"
+            + "}";
+    String query = "{ topLevel { droid { cachedField } } }";
+    assertEquals("max-age=30, public", execute(schema, query));
+
+    String query2 = "{ topLevel { droid { uncachedField { cachedField } cachedField } } }";
+    assertNull(execute(schema, query2));
+
+    String query3 = "{ topLevel { droids { uncachedField { cachedField } cachedField } } }";
+    assertNull(execute(schema, query3));
+  }
+
+  @Test
+  void inheritMaxAgeDocsExamples() {
+    String schema =
+        "type Query {\n"
+            + "  book: Book\n"
+            + "  cachedBook: Book @cacheControl(maxAge: 60)\n"
+            + "  reader: Reader @cacheControl(maxAge: 40)\n"
+            + "}\n"
+            + "type Book {\n"
+            + "  title: String\n"
+            + "  cachedTitle: String @cacheControl(maxAge: 30)\n"
+            + "}\n"
+            + "type Reader {\n"
+            + "  book: Book @cacheControl(inheritMaxAge: true)\n"
+            + "}";
+
+    assertNull(execute(schema, "{book{cachedTitle}}"));
+    assertEquals("max-age=60, public", execute(schema, "{cachedBook{title}}"));
+    assertEquals("max-age=30, public", execute(schema, "{cachedBook{cachedTitle}}"));
+    assertEquals("max-age=40, public", execute(schema, "{reader{book{title}}}"));
+  }
+
+  @Test
+  void inheritMaxAgeWithScope() {
+    String schema =
+        "type Query {\n"
+            + "  topLevel: TopLevel @cacheControl(maxAge: 500)\n"
+            + "}\n"
+            + "type TopLevel {\n"
+            + "  foo: Foo @cacheControl(inheritMaxAge: true, scope: PRIVATE)\n"
+            + "}\n"
+            + "type Foo {\n"
+            + "  bar: String @cacheControl(maxAge: 5)\n"
+            + "}";
+    String query = "{topLevel { foo { bar } } }";
+    assertEquals("max-age=5, private", execute(schema, query));
+  }
+
+  @Test
+  void inheritMaxAgeOnTypes() {
+    String schema =
+        "type Query {\n"
+            + "  topLevel: TopLevel @cacheControl(maxAge: 500)\n"
+            + "}\n"
+            + "type TopLevel {\n"
+            + "  foo: Foo\n"
+            + "}\n"
+            + "type Foo @cacheControl(inheritMaxAge: true) {\n"
+            + "  bar: String\n"
+            + "}";
+    String query = "{topLevel { foo { bar } } }";
+    assertEquals("max-age=500, public", execute(schema, query));
+  }
+
+  @Test
+  void scalarInheritFromGrandparents() {
+    String schema =
+        "type Query {\n"
+            + "  foo: Foo @cacheControl(maxAge: 5)\n"
+            + "}\n"
+            + "type Foo {\n"
+            + "  bar: Bar @cacheControl(inheritMaxAge: true)\n"
+            + "  defaultBar: Bar\n"
+            + "}\n"
+            + "type Bar {\n"
+            + "  scalar: String\n"
+            + "  cachedScalar: String @cacheControl(maxAge: 2)\n"
+            + "}";
+    assertNull(execute(schema, "{foo{defaultBar{scalar}}}"));
+    assertNull(execute(schema, "{foo{defaultBar{cachedScalar}}}"));
+    assertEquals("max-age=5, public", execute(schema, "{foo{bar{scalar}}}"));
+    assertEquals("max-age=2, public", execute(schema, "{foo{bar{cachedScalar}}}"));
+  }
+
+  @Test
+  void entities() {
+    String schema =
+        "type Product @key(fields: \"id\") @cacheControl(maxAge: 60) {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}"
+            + ""
+            + "type User @key(fields: \"id\") @cacheControl(maxAge: 30) {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+    String query =
+        "query ($rs: [_Any!]!) { _entities(representations: $rs) { ... on Product { id } ... on User { id } } }";
+
+    HashMap<String, Object> variables = new HashMap<>();
+    ArrayList<Object> rs = new ArrayList<>();
+
+    HashMap<Object, Object> product = new HashMap<>();
+    product.put("__typename", "Product");
+    product.put("id", "1");
+
+    HashMap<Object, Object> user = new HashMap<>();
+    user.put("__typename", "User");
+    user.put("id", "2");
+
+    rs.add(product);
+    rs.add(user);
+
+    variables.put("rs", rs);
+    assertEquals("max-age=30, public", execute(schema, query, 0, variables));
+  }
+}

--- a/spring-example/src/main/java/com/apollographql/federation/springexample/graphqljava/AppConfiguration.java
+++ b/spring-example/src/main/java/com/apollographql/federation/springexample/graphqljava/AppConfiguration.java
@@ -2,6 +2,7 @@ package com.apollographql.federation.springexample.graphqljava;
 
 import com.apollographql.federation.graphqljava.Federation;
 import com.apollographql.federation.graphqljava._Entity;
+import com.apollographql.federation.graphqljava.caching.CacheControlInstrumentation;
 import com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation;
 import graphql.schema.GraphQLSchema;
 import java.io.IOException;
@@ -46,5 +47,10 @@ public class AppConfiguration {
   @Bean
   public FederatedTracingInstrumentation federatedTracingInstrumentation() {
     return new FederatedTracingInstrumentation(new FederatedTracingInstrumentation.Options(true));
+  }
+
+  @Bean
+  public CacheControlInstrumentation cacheControlInstrumentation() {
+    return new CacheControlInstrumentation();
   }
 }

--- a/spring-example/src/main/java/com/apollographql/federation/springexample/graphqljavatools/AppConfiguration.java
+++ b/spring-example/src/main/java/com/apollographql/federation/springexample/graphqljavatools/AppConfiguration.java
@@ -2,6 +2,7 @@ package com.apollographql.federation.springexample.graphqljavatools;
 
 import com.apollographql.federation.graphqljava.SchemaTransformer;
 import com.apollographql.federation.graphqljava._Entity;
+import com.apollographql.federation.graphqljava.caching.CacheControlInstrumentation;
 import com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation;
 import graphql.schema.GraphQLSchema;
 import java.util.List;
@@ -42,5 +43,10 @@ public class AppConfiguration {
   @Bean
   public FederatedTracingInstrumentation federatedTracingInstrumentation() {
     return new FederatedTracingInstrumentation(new FederatedTracingInstrumentation.Options(true));
+  }
+
+  @Bean
+  public CacheControlInstrumentation cacheControlInstrumentation() {
+    return new CacheControlInstrumentation();
   }
 }

--- a/spring-example/src/main/resources/schemas/graphql-java-tools/inventory.graphqls
+++ b/spring-example/src/main/resources/schemas/graphql-java-tools/inventory.graphqls
@@ -1,6 +1,17 @@
 type Query
 
-type Product @key(fields: "upc") @extends {
+enum CacheControlScope {
+    PUBLIC
+    PRIVATE
+}
+
+directive @cacheControl(
+    maxAge: Int
+    scope: CacheControlScope
+    inheritMaxAge: Boolean
+) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+type Product @key(fields: "upc") @extends @cacheControl(maxAge: 60) {
     upc: String! @external
     inStock: Boolean
     quantity: Int

--- a/spring-example/src/main/resources/schemas/graphql-java/inventory.graphql
+++ b/spring-example/src/main/resources/schemas/graphql-java/inventory.graphql
@@ -1,4 +1,15 @@
-type Product @key(fields: "upc") @extends {
+enum CacheControlScope {
+    PUBLIC
+    PRIVATE
+}
+
+directive @cacheControl(
+    maxAge: Int
+    scope: CacheControlScope
+    inheritMaxAge: Boolean
+) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+type Product @key(fields: "upc") @extends @cacheControl(maxAge: 60) {
     upc: String! @external
     inStock: Boolean
     quantity: Int


### PR DESCRIPTION
This change adds support for the @cacheControl directive in the form of a graphql-java instrumentation class, matching the behavior of the apollo-server's built-in cache control plugin:

https://github.com/apollographql/apollo-server/tree/291c17e255122d4733b23177500188d68fac55ce/packages/apollo-server-core/src/plugin/cacheControl

As well as the special _entities behavior in @apollo/subgraph:

https://github.com/apollographql/federation/blob/00c89f82bfcc2e27e6714d894874422f84ae468c/subgraph-js/src/types.ts#L76-L87

This change does not support setting cache hints dynamically in resolvers, only static cache hints in SDL directives.

The instrumentation emits the value in the response's extensions object. Apollo Gateway looks for a cache-control policy in a subgraph's HTTP headers, so it's up to the subgraph service owner to pluck the value off the extensions and add it as a response header.