### PR TITLE
Add Adoptium in the list of approved vendors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,7 @@
                                     </requireActiveProfile>
                                     <requireJavaVendor>
                                         <includes>
+                                            <include>Eclipse Adoptium</include>
                                             <include>AdoptOpenJDK</include>
                                             <include>Azul Systems, Inc.</include>
                                         </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
                                     </requireActiveProfile>
                                     <requireJavaVendor>
                                         <includes>
-                                            <include>Eclipse Adoptium</include>
+                                            <include>Temurin</include>
                                             <include>AdoptOpenJDK</include>
                                             <include>Azul Systems, Inc.</include>
                                         </includes>


### PR DESCRIPTION
See https://github.com/AdoptOpenJDK/install-jdk/issues/21#issuecomment-905345179. AdoptOpenJDK was renamed to `Eclipse Adoptium`. 

The maven enforcer checks run locally because I still have an older install of Java 8 but looks like Circle CI has updated their versions.