### PR TITLE
add support for graphql-java context map

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -464,11 +464,12 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
      *     request (default: null). Note that when Apollo Gateway provides an HTTP header with name
      *     "apollo-federation-include-trace" and value "ftv1", you must enable tracing for the
      *     request, and it is your responsibility to augment your {@link ExecutionInput} or its
-     *     context to contain the information necessary for this predicate to have the the above
-     *     behavior. The default/null behavior is to enable trace generation unless the context both
-     *     implements {@link HTTPRequestHeaders} and calling {@link
-     *     HTTPRequestHeaders#getHTTPRequestHeader(String)} with "apollo-federation-include-trace"
-     *     returns a value that is null or isn't "ftv1".
+     *     context to contain the information necessary for this predicate to have the above
+     *     behavior. The default/null behavior is to enable trace generation unless the
+     *     GraphQLContext map contains "apollo-federation-include-trace" entry with a value other
+     *     than null/"ftv1" or if (deprecated) context both implements {@link HTTPRequestHeaders}
+     *     and calling {@link HTTPRequestHeaders#getHTTPRequestHeader(String)} with
+     *     "apollo-federation-include-trace" returns a value that is null or isn't "ftv1".
      */
     public Options(
         boolean debuggingEnabled, @Nullable Predicate<ExecutionInput> shouldTracePredicate) {
@@ -493,13 +494,20 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
         return shouldTracePredicate.test(executionInput);
       }
 
-      // Default/null implementation as described in the javadoc for the Options constructor.
-      if (executionInput != null && executionInput.getContext() != null) {
-        Object context = executionInput.getContext();
-        if (context instanceof HTTPRequestHeaders) {
-          String header =
-              ((HTTPRequestHeaders) context).getHTTPRequestHeader(FEDERATED_TRACING_HEADER_NAME);
-          return FEDERATED_TRACING_HEADER_VALUE.equals(header);
+      if (executionInput != null) {
+        // Default/null implementation as described in the javadoc for the Options constructor.
+        if (executionInput.getGraphQLContext().hasKey(FEDERATED_TRACING_HEADER_NAME)) {
+          return FEDERATED_TRACING_HEADER_VALUE.equals(
+              executionInput.getGraphQLContext().get(FEDERATED_TRACING_HEADER_NAME));
+        } else if (executionInput.getContext() != null) {
+          // ExecutionInput#getContext which returns arbitrary object is deprecated
+          // usage should be replaced by ExecutionInput#getGraphQLContext which returns a map
+          Object context = executionInput.getContext();
+          if (context instanceof HTTPRequestHeaders) {
+            String header =
+                ((HTTPRequestHeaders) context).getHTTPRequestHeader(FEDERATED_TRACING_HEADER_NAME);
+            return FEDERATED_TRACING_HEADER_VALUE.equals(header);
+          }
         }
       }
       return true;

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -467,7 +467,7 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
      *     context to contain the information necessary for this predicate to have the above
      *     behavior. The default/null behavior is to enable trace generation unless the
      *     GraphQLContext map contains "apollo-federation-include-trace" entry with a value other
-     *     than null/"ftv1" or if (deprecated) context both implements {@link HTTPRequestHeaders}
+     *     than "ftv1" or if (deprecated) context both implements {@link HTTPRequestHeaders}
      *     and calling {@link HTTPRequestHeaders#getHTTPRequestHeader(String)} with
      *     "apollo-federation-include-trace" returns a value that is null or isn't "ftv1".
      */

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -467,8 +467,8 @@ public class FederatedTracingInstrumentation extends SimpleInstrumentation {
      *     context to contain the information necessary for this predicate to have the above
      *     behavior. The default/null behavior is to enable trace generation unless the
      *     GraphQLContext map contains "apollo-federation-include-trace" entry with a value other
-     *     than "ftv1" or if (deprecated) context both implements {@link HTTPRequestHeaders}
-     *     and calling {@link HTTPRequestHeaders#getHTTPRequestHeader(String)} with
+     *     than "ftv1" or if (deprecated) context both implements {@link HTTPRequestHeaders} and
+     *     calling {@link HTTPRequestHeaders#getHTTPRequestHeader(String)} with
      *     "apollo-federation-include-trace" returns a value that is null or isn't "ftv1".
      */
     public Options(


### PR DESCRIPTION
`graphql-java` v17 introduced new `GraphQLContext` mechanism which standardized how context should be utilized. Prior to v17, context could be of any object and it was up to the developers to decide how it should look like. New `GraphQLContext` standardizes the approach and is a simple wrapper around a map.

Updated default `FederatedTracingInstrumentation.Options#shouldTrace` method to also check the `GraphQLContext` map contents if it contains an entry for `apollo-federation-include-trace`.