### PR TITLE
Use bom version 2.13.2.20220328 for Jackson dependencies

### DIFF
--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -72,28 +72,6 @@
                 <scope>test</scope>
             </dependency>
             <!--
-            The following dependencies exist solely to override Maven's default "nearest first" strategy for transitive
-            dependency version conflict resolution. Note that as stated in the parent POM, we would normally use Maven
-            <exclusions> instead to get transitivity, but since spring-example isn't designed to be imported, it's fine
-            (and a lot less work in this case) to just add dependencies to <dependencyManagement>.
-            -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-            </dependency>
-            <!--
             There is a bug in com.graphql-java-kickstart:graphql-spring-boot-starter:11.1.0 where it depends on
             artifact com.graphql-java:graphql-java-extended-scalars:16.0.1, but it really needs 17.0. This forces
             us to a later version.

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -20,12 +20,19 @@
         <graphql-java-tools.version>11.1.2</graphql-java-tools.version>
         <!-- Note that spring-example wasn't designed to be imported, so this is fine. -->
         <skip.dependency.convergence>true</skip.dependency.convergence>
-        <fasterxml.jackson.version>2.12.5</fasterxml.jackson.version>
+        <fasterxml.jackson.bom.version>2.13.2.20220328</fasterxml.jackson.bom.version>
         <spring-boot.version>2.5.4</spring-boot.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${fasterxml.jackson.bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>com.graphql-java-kickstart</groupId>
                 <artifactId>graphql-spring-boot-starter</artifactId>
@@ -73,22 +80,18 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${fasterxml.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${fasterxml.jackson.version}</version>
             </dependency>
             <!--
             There is a bug in com.graphql-java-kickstart:graphql-spring-boot-starter:11.1.0 where it depends on


### PR DESCRIPTION
Following [this Dependabot PR](https://github.com/apollographql/federation-jvm/pull/146) which tries to address [this CVE](https://github.com/FasterXML/jackson-databind/issues/2816) but bumps the dependencies globally which doesn't work - this PR uses [the BOM](https://github.com/FasterXML/jackson-bom) instead.