### PR TITLE
Hotfix for federation2 _entities resolver not being present when computing sdl

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -160,10 +160,10 @@ public final class SchemaTransformer {
 
       sdl =
           new FederationSdlPrinter(
-              FederationSdlPrinter.Options.defaultOptions()
-                  .includeScalarTypes(true)
-                  .includeDirectiveDefinitions(
-                      def -> !standardDirectives.contains(def.getName())))
+                  FederationSdlPrinter.Options.defaultOptions()
+                      .includeScalarTypes(true)
+                      .includeDirectiveDefinitions(
+                          def -> !standardDirectives.contains(def.getName())))
               .print(newSchema.codeRegistry(newCodeRegistry.build()).build())
               .trim();
     } else {
@@ -172,9 +172,7 @@ public final class SchemaTransformer {
     }
     newCodeRegistry.dataFetcher(
         FieldCoordinates.coordinates(_Service.typeName, _Service.sdlFieldName),
-        (DataFetcher<String>) environment -> sdl
-    );
-
+        (DataFetcher<String>) environment -> sdl);
 
     return newSchema.codeRegistry(newCodeRegistry.build()).build();
   }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -223,14 +223,13 @@ class FederationTest {
 
   @Test
   void testFed2() {
-    final GraphQLSchema federatedSchema = Federation.transform(fed2SDL)
-        .resolveEntityType(env -> env.getSchema().getObjectType("Point"))
-        .fetchEntities(entityFetcher -> ImmutableMap.builder()
-            .put("id", "1000")
-            .put("x", 0)
-            .put("y", 0)
-            .build())
-        .build();
+    final GraphQLSchema federatedSchema =
+        Federation.transform(fed2SDL)
+            .resolveEntityType(env -> env.getSchema().getObjectType("Point"))
+            .fetchEntities(
+                entityFetcher ->
+                    ImmutableMap.builder().put("id", "1000").put("x", 0).put("y", 0).build())
+            .build();
     SchemaUtils.assertSDL(federatedSchema, fed2FederatedSDL, fed2ServiceSDL);
   }
 }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import graphql.ExecutionResult;
 import graphql.Scalars;
+import graphql.com.google.common.collect.ImmutableMap;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLObjectType;
@@ -222,7 +223,14 @@ class FederationTest {
 
   @Test
   void testFed2() {
-    final GraphQLSchema federatedSchema = Federation.transform(fed2SDL).build();
+    final GraphQLSchema federatedSchema = Federation.transform(fed2SDL)
+        .resolveEntityType(env -> env.getSchema().getObjectType("Point"))
+        .fetchEntities(entityFetcher -> ImmutableMap.builder()
+            .put("id", "1000")
+            .put("x", 0)
+            .put("y", 0)
+            .build())
+        .build();
     SchemaUtils.assertSDL(federatedSchema, fed2FederatedSDL, fed2ServiceSDL);
   }
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2.graphql
@@ -2,7 +2,8 @@ extend schema
     @link(url: "https://specs.apollo.dev/federation/v2.0",
        import: ["@key", "@shareable", "@tag"])
 
-type Position @shareable {
+type Position @shareable @key(fields: "id") {
+ id: ID!
  x: Int!
  y: Int!
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Federated.graphql
@@ -14,18 +14,24 @@ directive @shareable on OBJECT | FIELD_DEFINITION
 
 directive @tag repeatable on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
 
-type Position @shareable {
+union _Entity = Position
+
+type Position @key(fields : "id") @shareable {
+  id: ID!
   x: Int!
   y: Int!
 }
 
 type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 
 type _Service {
   sdl: String!
 }
+
+scalar _Any
 
 scalar _FieldSet
 

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Service.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Service.graphql
@@ -14,18 +14,24 @@ directive @shareable on OBJECT | FIELD_DEFINITION
 
 directive @tag repeatable on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
 
-type Position @shareable {
+union _Entity = Position
+
+type Position @key(fields : "id") @shareable {
+  id: ID!
   x: Int!
   y: Int!
 }
 
 type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
   _service: _Service
 }
 
 type _Service {
   sdl: String!
 }
+
+scalar _Any
 
 scalar _FieldSet
 


### PR DESCRIPTION
- make test fail
- move computing the "sdl" field to the end so that we have a valid codeRegistry
