### PR TITLE
Fix unions not working

### DIFF
--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -51,6 +51,9 @@ class FederationTest {
   private final String fed2SDL = TestUtils.readResource("schemas/fed2.graphql");
   private final String fed2FederatedSDL = TestUtils.readResource("schemas/fed2Federated.graphql");
   private final String fed2ServiceSDL = TestUtils.readResource("schemas/fed2Service.graphql");
+  private final String unionsSDL = TestUtils.readResource("schemas/unions.graphql");
+  private final String unionsFederatedSDL =
+      TestUtils.readResource("schemas/unionsFederated.graphql");
 
   @Test
   void testEmptySDL() {
@@ -231,5 +234,13 @@ class FederationTest {
                     ImmutableMap.builder().put("id", "1000").put("x", 0).put("y", 0).build())
             .build();
     SchemaUtils.assertSDL(federatedSchema, fed2FederatedSDL, fed2ServiceSDL);
+  }
+
+  @Test
+  void testUnions() {
+    final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+    runtimeWiring.getTypeResolvers().put("ProductResult", env -> null);
+    final GraphQLSchema federatedSchema = Federation.transform(unionsSDL, runtimeWiring).build();
+    SchemaUtils.assertSDL(federatedSchema, unionsFederatedSDL, unionsSDL);
   }
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/unions.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/unions.graphql
@@ -1,0 +1,20 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+union ProductResult = Product | ProductError
+
+type Mutation {
+  createProduct(symbol: String!): ProductResult
+}
+
+type Product {
+  symbol: String!
+}
+
+type ProductError {
+  reason: String
+}
+
+type Query

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/unionsFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/unionsFederated.graphql
@@ -1,0 +1,33 @@
+directive @extends on OBJECT | INTERFACE
+
+directive @external on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+union ProductResult = Product | ProductError
+
+type Mutation {
+  createProduct(symbol: String!): ProductResult
+}
+
+type Product {
+  symbol: String!
+}
+
+type ProductError {
+  reason: String
+}
+
+type Query {
+  _service: _Service
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _FieldSet


### PR DESCRIPTION
This should fix #154.

In some cases, `copyRuntimeWiring` didn't copy some of the typeResolvers from the original. This is the case of typeResolvers for Unions and Interfaces added inside Spring Graphql [here](https://github.com/spring-projects/spring-graphql/blob/main/spring-graphql/src/main/java/org/springframework/graphql/execution/DefaultGraphQlSourceBuilder.java#L177).

(I am sorry applying spotless changed a bit of formatting from unrelated lines.)