### PR TITLE
Add support for rename imports

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -222,10 +222,10 @@ public final class Federation {
           if (def instanceof ScalarTypeDefinition
               && !runtimeWiring.getScalars().containsKey(def.getName())) {
             scalarTypesToAdd.add(
-                GraphQLScalarType.newScalar(Scalars.GraphQLString)
+                GraphQLScalarType.newScalar()
                     .name(def.getName())
                     .description(null)
-                    .coercing(Scalars.GraphQLString.getCoercing())
+                    .coercing(_Any.defaultCoercing)
                     .build());
           }
         });
@@ -394,7 +394,7 @@ public final class Federation {
                         as = null;
                       } else {
                         Value asValue = asField.get().getValue();
-                        if (asValue instanceof StringValue) {
+                        if (!(asValue instanceof StringValue)) {
                           throw new RuntimeException("Unsupported import: " + imp);
                         }
                         as = ((StringValue) asValue).getValue();

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -2,7 +2,6 @@ package com.apollographql.federation.graphqljava;
 
 import static graphql.util.TreeTransformerUtil.changeNode;
 
-import graphql.Scalars;
 import graphql.language.*;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
@@ -157,7 +156,11 @@ public final class Federation {
       key = name;
     }
 
-    if (key.equals("String") || key.equals("Boolean") || key.equals("Int") || key.equals("Float") || key.equals("ID")) {
+    if (key.equals("String")
+        || key.equals("Boolean")
+        || key.equals("Int")
+        || key.equals("Float")
+        || key.equals("ID")) {
       // Do not rename builtin types
       return name;
     }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -1,12 +1,7 @@
 package com.apollographql.federation.graphqljava;
 
-import graphql.language.DirectiveDefinition;
-import graphql.language.FieldDefinition;
-import graphql.language.ObjectTypeDefinition;
-import graphql.language.StringValue;
-import graphql.language.TypeDefinition;
-import graphql.language.TypeName;
-import graphql.language.Value;
+import graphql.Scalars;
+import graphql.language.*;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
@@ -14,19 +9,26 @@ import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
+
 import java.io.File;
 import java.io.Reader;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import graphql.util.TraversalControl;
+import graphql.util.TraverserContext;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static graphql.util.TreeTransformerUtil.changeNode;
 
 public final class Federation {
   private static final SchemaGenerator.Options generatorOptions =
       SchemaGenerator.Options.defaultOptions();
 
-  private Federation() {}
+  private Federation() {
+  }
 
   @NotNull
   public static SchemaTransformer transform(final GraphQLSchema schema) {
@@ -50,13 +52,18 @@ public final class Federation {
       final TypeDefinitionRegistry typeRegistry, final RuntimeWiring runtimeWiring) {
     final boolean queryTypeShouldBeEmpty = ensureQueryTypeExists(typeRegistry);
 
-    boolean isFederation2 = isFederation2(typeRegistry);
-    RuntimeWiring newRuntimeWiring =
-        ensureFederationDirectiveDefinitionsExist(typeRegistry, runtimeWiring, isFederation2);
+    @Nullable Map<String, String> fed2Imports = fed2DirectiveImports(typeRegistry);
+    RuntimeWiring newRuntimeWiring;
+
+    if (fed2Imports != null) {
+      newRuntimeWiring = ensureFederation2DirectiveDefinitionsExist(typeRegistry, runtimeWiring, fed2Imports);
+    } else {
+      newRuntimeWiring = ensureFederationDirectiveDefinitionsExist(typeRegistry, runtimeWiring);
+    }
     final GraphQLSchema original =
         new SchemaGenerator()
             .makeExecutableSchema(generatorOptions, typeRegistry, newRuntimeWiring);
-    return transform(original, queryTypeShouldBeEmpty).setFederation2(isFederation2);
+    return transform(original, queryTypeShouldBeEmpty).setFederation2(fed2Imports != null);
   }
 
   public static SchemaTransformer transform(final TypeDefinitionRegistry typeRegistry) {
@@ -111,9 +118,9 @@ public final class Federation {
         newQueryType instanceof ObjectTypeDefinition
             && ((ObjectTypeDefinition) newQueryType).getFieldDefinitions().isEmpty()
             && Optional.ofNullable(typeRegistry.objectTypeExtensions().get(queryName))
-                // Note that an object type extension must have at least one field
-                .map(List::isEmpty)
-                .orElse(true);
+            // Note that an object type extension must have at least one field
+            .map(List::isEmpty)
+            .orElse(true);
     if (addDummyField) {
       newQueryType =
           ((ObjectTypeDefinition) newQueryType)
@@ -132,14 +139,100 @@ public final class Federation {
     return addDummyField;
   }
 
-  private static RuntimeWiring ensureFederationDirectiveDefinitionsExist(
-      TypeDefinitionRegistry typeRegistry, RuntimeWiring runtimeWiring, boolean isFederation2) {
-    Set<DirectiveDefinition> directivesToAdd;
-    if (isFederation2) {
-      directivesToAdd = FederationDirectives.federation2DirectiveDefinitions;
+  private static Stream<SDLNamedDefinition> renameDefinitions(List<SDLNamedDefinition> sdlNamedDefinition, Map<String, String> fed2Imports) {
+    return sdlNamedDefinition.stream().map(definition -> {
+      SDLNamedDefinition newDefinition = (SDLNamedDefinition) new AstTransformer().transform(definition, new RenamingVisitor(fed2Imports));
+      return newDefinition;
+    });
+  }
+
+  private static String newName(String name, Map<String, String> fed2Imports, boolean isDirective) {
+    String key;
+    if (isDirective) {
+      key = "@" + name;
     } else {
-      directivesToAdd = FederationDirectives.federation1DirectiveDefinitions;
+      key = name;
     }
+
+    if (key.equals("String")
+        || key.equals("Boolean")
+        || key.equals("Int")
+        || key.equals("Float")) {
+      // Do not rename builtin types
+      return name;
+    }
+
+    if (fed2Imports.containsKey(key)) {
+      String newName = fed2Imports.get(key);
+      if (isDirective) {
+        return newName.substring(1);
+      } else {
+        return newName;
+      }
+    } else {
+      return "federation__" + name;
+    }
+  }
+
+  static class RenamingVisitor extends NodeVisitorStub {
+    private Map<String, String> fed2Imports;
+
+    public RenamingVisitor(Map<String, String> fed2Imports) {
+      this.fed2Imports = fed2Imports;
+    }
+
+    @Override
+    protected TraversalControl visitNode(Node node, TraverserContext<Node> context) {
+      if (node instanceof NamedNode) {
+        Node newNode = null;
+        if (node instanceof TypeName) {
+          String newName = newName(((NamedNode<?>) node).getName(), fed2Imports, false);
+          newNode = ((TypeName) node).transform(builder -> builder.name(newName));
+        } else if (node instanceof ScalarTypeDefinition) {
+          String newName = newName(((NamedNode<?>) node).getName(), fed2Imports, false);
+          newNode = ((ScalarTypeDefinition) node).transform(builder -> builder.name(newName));
+        } else if (node instanceof DirectiveDefinition) {
+          String newName = newName(((NamedNode<?>) node).getName(), fed2Imports, true);
+          newNode = ((DirectiveDefinition) node).transform(builder -> builder.name(newName));
+        }
+        if (newNode != null) {
+          return changeNode(context, newNode);
+        }
+      }
+      return super.visitNode(node, context);
+    }
+  }
+
+  private static RuntimeWiring ensureFederation2DirectiveDefinitionsExist(
+      TypeDefinitionRegistry typeRegistry, RuntimeWiring runtimeWiring, @Nullable Map<String, String> fed2Imports) {
+
+    RuntimeWiring newRuntimeWiring = runtimeWiring;
+    HashSet<GraphQLScalarType> scalarTypesToAdd = new HashSet<GraphQLScalarType>();
+
+    Stream<SDLNamedDefinition> renamedDefinitions = renameDefinitions(FederationDirectives.federation2Definitions, fed2Imports);
+
+    renamedDefinitions.forEach(def -> {
+      if (!typeRegistry.getDirectiveDefinition(def.getName()).isPresent()) {
+        typeRegistry.add(def);
+      }
+      if (def instanceof ScalarTypeDefinition && !runtimeWiring.getScalars().containsKey(def.getName())) {
+        scalarTypesToAdd.add(
+            GraphQLScalarType.newScalar(Scalars.GraphQLString)
+                .name(def.getName())
+                .description(null)
+                .coercing(Scalars.GraphQLString.getCoercing())
+                .build()
+        );
+      }
+    });
+    return copyRuntimeWiring(newRuntimeWiring, scalarTypesToAdd);
+  }
+
+  private static RuntimeWiring ensureFederationDirectiveDefinitionsExist(
+      TypeDefinitionRegistry typeRegistry, RuntimeWiring runtimeWiring) {
+
+    Set<DirectiveDefinition> directivesToAdd;
+    directivesToAdd = FederationDirectives.federation1DirectiveDefinitions;
 
     // Add Federation directives if they don't exist.
     directivesToAdd.stream()
@@ -155,17 +248,6 @@ public final class Federation {
     RuntimeWiring newRuntimeWiring = runtimeWiring;
     if (!runtimeWiring.getScalars().containsKey(_FieldSet.typeName)) {
       newRuntimeWiring = copyRuntimeWiring(newRuntimeWiring, Collections.singleton(_FieldSet.type));
-    }
-
-    // Add scalar type for link__Import, since the directives depend on it.
-    if (isFederation2) {
-      if (!typeRegistry.getType(link__Import.typeName).isPresent()) {
-        typeRegistry.add(link__Import.definition);
-      }
-      if (!runtimeWiring.getScalars().containsKey(link__Import.typeName)) {
-        newRuntimeWiring =
-            copyRuntimeWiring(newRuntimeWiring, Collections.singleton(link__Import.type));
-      }
     }
 
     return newRuntimeWiring;
@@ -218,24 +300,100 @@ public final class Federation {
     return runtimeWiringCopy;
   }
 
-  public static boolean isFederation2(TypeDefinitionRegistry typeDefinitionRegistry) {
-    return typeDefinitionRegistry.getSchemaExtensionDefinitions().stream()
-        .anyMatch(
-            schemaExtensionDefinition ->
-                schemaExtensionDefinition.getDirectives().stream()
-                    .anyMatch(
-                        directive ->
-                            directive.getName().equals("link")
-                                && directive.getArguments().stream()
-                                    .anyMatch(
-                                        argument -> {
-                                          Value value = argument.getValue();
-                                          return argument.getName().equals("url")
-                                              && value instanceof StringValue
-                                              && ((StringValue) value)
-                                                  .getValue()
-                                                  .equals(
-                                                      "https://specs.apollo.dev/federation/v2.0");
-                                        })));
+  /**
+   * Looks for an @link extension and gets the import from it
+   *
+   * @return - null if this typeDefinitionRegistry is not Fed2
+   * - the list of imports and potential renames else
+   */
+  private static @Nullable Map<String, String> fed2DirectiveImports(TypeDefinitionRegistry typeDefinitionRegistry) {
+    Map<String, String> imports = typeDefinitionRegistry.getSchemaExtensionDefinitions().stream()
+        .flatMap(
+            schemaExtensionDefinition -> schemaExtensionDefinition.getDirectives().stream().filter(
+                directive -> directive.getName().equals("link")
+            )
+        )
+        .filter(
+            directive -> {
+              Optional<Argument> arg = directive.getArguments().stream().filter(argument -> argument.getName().equals("url")).findFirst();
+
+              if (!arg.isPresent()) {
+                return false;
+              }
+
+              Value value = arg.get().getValue();
+              if (!(value instanceof StringValue)) {
+                return false;
+              }
+
+              StringValue stringValue = (StringValue) value;
+              return stringValue.getValue().equals("https://specs.apollo.dev/federation/v2.0");
+            }
+        ).flatMap(
+            directive -> {
+              Optional<Argument> arg = directive.getArguments().stream().filter(argument -> argument.getName().equals("import")).findFirst();
+
+              if (!arg.isPresent()) {
+                return Stream.empty();
+              }
+
+              Value value = arg.get().getValue();
+              if (!(value instanceof ArrayValue)) {
+                return Stream.empty();
+              }
+
+              ArrayValue arrayValue = (ArrayValue) value;
+
+              List<Map.Entry<String, String>> entries = new ArrayList<>();
+
+              for (Value imp : arrayValue.getValues()) {
+                if (imp instanceof StringValue) {
+                  String name = ((StringValue) imp).getValue();
+                  entries.add(new AbstractMap.SimpleEntry(name, name));
+                } else if (imp instanceof ObjectValue) {
+                  ObjectValue objectValue = (ObjectValue) imp;
+                  Optional<ObjectField> nameField = objectValue.getObjectFields().stream().filter(field -> field.getName().equals("name")).findFirst();
+                  Optional<ObjectField> asField = objectValue.getObjectFields().stream().filter(field -> field.getName().equals("as")).findFirst();
+
+                  if (!nameField.isPresent()) {
+                    throw new RuntimeException("Unsupported import: " + imp);
+                  }
+
+                  Value nameValue = nameField.get().getValue();
+                  if (!(nameValue instanceof StringValue)) {
+                    throw new RuntimeException("Unsupported import: " + imp);
+                  }
+
+                  String as;
+                  if (!asField.isPresent()) {
+                    as = null;
+                  } else {
+                    Value asValue = asField.get().getValue();
+                    if (asValue instanceof StringValue) {
+                      throw new RuntimeException("Unsupported import: " + imp);
+                    }
+                    as = ((StringValue) asValue).getValue();
+                  }
+
+                  entries.add(new AbstractMap.SimpleEntry(((StringValue) nameValue).getValue(), as));
+                } else {
+                  throw new RuntimeException("Unsupported import: " + imp.toString());
+                }
+              }
+
+              return entries.stream();
+            }
+        )
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (value1, value2) -> value2
+            )
+        );
+
+    // Add hardcoded @link to avoid having federation__link all over the place
+    imports.put("@link", "@link");
+    return  imports;
   }
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -157,7 +157,7 @@ public final class Federation {
       key = name;
     }
 
-    if (key.equals("String") || key.equals("Boolean") || key.equals("Int") || key.equals("Float")) {
+    if (key.equals("String") || key.equals("Boolean") || key.equals("Int") || key.equals("Float") || key.equals("ID")) {
       // Do not rename builtin types
       return name;
     }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -13,7 +13,6 @@ import graphql.parser.Parser;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLNonNull;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -155,8 +154,10 @@ public final class FederationDirectives {
   public static final Set<DirectiveDefinition> federation1DirectiveDefinitions;
 
   private static List<SDLNamedDefinition> fed2Definitions() {
-    InputStream inputStream = FederationDirectives.class.getClassLoader().getResourceAsStream("fed2directives.graphqls");
-    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+    InputStream inputStream =
+        FederationDirectives.class.getClassLoader().getResourceAsStream("fed2directives.graphqls");
+    BufferedReader reader =
+        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
     try {
       Document document = new Parser().parseDocument(reader);
 

--- a/graphql-java-support/src/main/resources/fed2directives.graphqls
+++ b/graphql-java-support/src/main/resources/fed2directives.graphqls
@@ -1,0 +1,29 @@
+# Fed2 directives taken from https://github.com/apollographql/federation/blob/c68e501b4c02bd65f6b0bbbabf1b2aa4a2ab3c47/subgraph-js/src/federation-atlas.ts
+# 
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @extends on OBJECT | INTERFACE
+directive @override(from: String!) on FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+scalar FieldSet
+
+directive @link(url: String!, as: String, import: [Import]) repeatable on SCHEMA
+
+scalar Import

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2.graphql
@@ -1,9 +1,9 @@
 extend schema
     @link(url: "https://specs.apollo.dev/federation/v2.0",
-       import: ["@key", "@shareable", "@tag", "@override"])
+       import: ["@key", "@shareable", {name: "@tag" as :"@apollo_tag"}, "@override"])
 
 type Position @shareable @key(fields: "id", resolvable: false) {
- id: ID! @tag(name: "internal")
+ id: ID! @apollo_tag(name: "internal")
  x: Int! @override(from: "otherGraph")
  y: Int!
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2.graphql
@@ -1,6 +1,6 @@
 extend schema
     @link(url: "https://specs.apollo.dev/federation/v2.0",
-       import: ["@key", "@shareable", "@tag"])
+       import: ["@key", "@shareable", "@tag", "@override"])
 
 type Position @shareable @key(fields: "id", resolvable: false) {
  id: ID! @tag(name: "internal")

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Federated.graphql
@@ -1,22 +1,22 @@
-directive @extends on OBJECT | INTERFACE
+directive @federation__extends on OBJECT | INTERFACE
 
-directive @external on FIELD_DEFINITION
+directive @federation__external on OBJECT | FIELD_DEFINITION
 
-directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, import: [federation__Import], url: String!) repeatable on SCHEMA
 
 directive @override(from: String!) on FIELD_DEFINITION
 
-directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
 directive @shareable on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Position
 
@@ -37,6 +37,6 @@ type _Service {
 
 scalar _Any
 
-scalar _FieldSet
+scalar federation__FieldSet
 
-scalar link__Import
+scalar federation__Import

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Federated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Federated.graphql
@@ -16,12 +16,12 @@ directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITI
 
 directive @shareable on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @apollo_tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Position
 
 type Position @key(fields : "id", resolvable : false) @shareable {
-  id: ID! @tag(name : "internal")
+  id: ID! @apollo_tag(name : "internal")
   x: Int! @override(from : "otherGraph")
   y: Int!
 }

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Service.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Service.graphql
@@ -1,22 +1,22 @@
-directive @extends on OBJECT | INTERFACE
+directive @federation__extends on OBJECT | INTERFACE
 
-directive @external on FIELD_DEFINITION
+directive @federation__external on OBJECT | FIELD_DEFINITION
 
-directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @federation__inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, import: [federation__Import], url: String!) repeatable on SCHEMA
 
 directive @override(from: String!) on FIELD_DEFINITION
 
-directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
 
-directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
 directive @shareable on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Position
 
@@ -37,6 +37,6 @@ type _Service {
 
 scalar _Any
 
-scalar _FieldSet
+scalar federation__FieldSet
 
-scalar link__Import
+scalar federation__Import

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Service.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/fed2Service.graphql
@@ -16,12 +16,12 @@ directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITI
 
 directive @shareable on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @apollo_tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Position
 
 type Position @key(fields : "id", resolvable : false) @shareable {
-  id: ID! @tag(name : "internal")
+  id: ID! @apollo_tag(name : "internal")
   x: Int! @override(from : "otherGraph")
   y: Int!
 }


### PR DESCRIPTION
This adds support for renaming directives like:

```graphql
extend schema
    @link(url: "https://specs.apollo.dev/federation/v2.0",
       import: ["@key", "@shareable", {name: "@tag" as :"@apollo_tag"}, "@override"])
```

If the directive is not imported, it can still be used with the `federation__` prefix:

```graphql
type Position @federation__external
```

Fixes https://github.com/apollographql/federation-jvm/issues/165