### PR TITLE
[WIP] Update graphql-java to 18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,10 +76,10 @@
         -->
         <skip.dependency.convergence>false</skip.dependency.convergence>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <graphql-java.version>17.3</graphql-java.version>
+        <graphql-java.version>18.1</graphql-java.version>
         <java.version>1.8</java.version>
         <jetbrains-annotations.version>17.0.0</jetbrains-annotations.version>
-        <junit.version>5.7.2</junit.version>
+        <junit.version>5.8.2</junit.version>
         <!-- Can't upgrade to 3.2.X until https://issues.apache.org/jira/browse/MDEP-753 is fixed. -->
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <!--
@@ -92,7 +92,7 @@
         <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <spotless.version>2.12.2</spotless.version>
     </properties>
 
@@ -350,11 +350,6 @@
                         <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring-boot.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/spring-example/pom.xml
+++ b/spring-example/pom.xml
@@ -16,12 +16,12 @@
     <description>Spring Boot example of federation-graphql-java-support usage</description>
 
     <properties>
-        <graphql-java-kickstart.version>11.1.0</graphql-java-kickstart.version>
-        <graphql-java-tools.version>11.1.2</graphql-java-tools.version>
+        <graphql-java-kickstart.version>12.0.0</graphql-java-kickstart.version>
+        <graphql-java-tools.version>12.0.2</graphql-java-tools.version>
         <!-- Note that spring-example wasn't designed to be imported, so this is fine. -->
         <skip.dependency.convergence>true</skip.dependency.convergence>
-        <fasterxml.jackson.version>2.12.5</fasterxml.jackson.version>
-        <spring-boot.version>2.5.4</spring-boot.version>
+        <fasterxml.jackson.version>2.13.2</fasterxml.jackson.version>
+        <spring-boot.version>2.6.7</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -34,13 +34,13 @@
             <dependency>
                 <groupId>com.graphql-java-kickstart</groupId>
                 <artifactId>graphiql-spring-boot-starter</artifactId>
-                <version>${graphql-java-kickstart.version}</version>
+                <version>11.1.0</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>com.graphql-java-kickstart</groupId>
                 <artifactId>graphql-spring-boot-starter-test</artifactId>
-                <version>${graphql-java-kickstart.version}</version>
+                <version>12.0.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${fasterxml.jackson.version}</version>
+                <version>2.13.2.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -131,6 +131,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>5.3.19</version>
         </dependency>
         <dependency>
             <groupId>com.graphql-java-kickstart</groupId>
@@ -229,6 +234,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/spring-example/src/main/resources/application.properties
+++ b/spring-example/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+debug=true


### PR DESCRIPTION
Currently on hold because `graphql-java-tools:12.0.2` is not compatible with `graphql-java:18.1`:

```
java.lang.NoSuchMethodError: graphql.schema.GraphQLDirective$Builder.comparatorRegistry(Lgraphql/schema/GraphqlTypeComparatorRegistry;)Lgraphql/schema/GraphQLDirective$Builder;
	at graphql.kickstart.tools.SchemaParser.buildDirectives(SchemaParser.kt:309) ~[graphql-java-tools-12.0.2.jar:na]
	at graphql.kickstart.tools.SchemaParser.createObject(SchemaParser.kt:125) ~[graphql-java-tools-12.0.2.jar:na]
	at graphql.kickstart.tools.SchemaParser.parseSchemaObjects(SchemaParser.kt:81) ~[graphql-java-tools-12.0.2.jar:na]
```

`GraphQLDirective.comparator` was removed in https://github.com/graphql-java/graphql-java/commit/a2d81a84ed027590106a8938819e0a1872ec4ad8