### PR TITLE
[build] group protobuf renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
       "groupName": "Gradle version updates",
       "matchPaths": ["gradle-wrapper.properties"],
       "labels": ["type: build"]
+    },
+    {
+      "groupName": "Protobuf",
+      "matchPackagePrefixes": ["com.google.protobuf:"]
     }
   ]
 }


### PR DESCRIPTION
It appears that built-in `group:monorepos` renovate rule does not handle protobuf updates. Adding explicit rule for handling protobuf updates.