### PR TITLE
[build] fix release workflow to correctly parse version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Publish libraries with Gradle
         run: |
-          NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
+          NEW_VERSION=$(echo "${GITHUB_REF}" | sed 's/.*\/v//')
           echo "New version: ${NEW_VERSION}"
           ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${NEW_VERSION}
         env:


### PR DESCRIPTION
Tags are prefixed with `v` so have to strip it to get the correct version.