### PR TITLE
[build] fix intellij configuration

### DIFF
--- a/buildSrc/src/main/kotlin/com.apollographql.federation.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.apollographql.federation.java-conventions.gradle.kts
@@ -85,6 +85,8 @@ spotless {
         removeUnusedImports()
         // Note that later versions use a bytecode target incompatible with Java SE 8
         googleJavaFormat("1.7")
+        // exclude generated proto
+        targetExclude("build/generated/**/*.java")
     }
 }
 

--- a/graphql-java-support/build.gradle.kts
+++ b/graphql-java-support/build.gradle.kts
@@ -27,3 +27,11 @@ protobuf {
         artifact = "com.google.protobuf:protoc:3.21.1"
     }
 }
+
+// gradle protobuf plugin currently does not correctly register the sources
+// this is a workaround for intellij to correctly recognize the generated sources
+// https://github.com/google/protobuf-gradle-plugin/issues/109
+sourceSets {
+    val main by getting { }
+    main.java.srcDirs("build/generated/source/proto/main/java")
+}


### PR DESCRIPTION
Protobuf plugin does not correctly register its generated sources meaning that Intellij does not see the generated classes. Updating configuration to explicitly register generated proto sources.