### PR TITLE
fix: SchemaTransformer entity lookup should look at applied directives

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -161,14 +161,14 @@ public final class SchemaTransformer {
    * @return Set containing all federated entity type names.
    */
   Set<String> getFederatedEntities() {
-    final Set<String> entityTypeNames =
+    final Set<String> entitiesWithExplicitKeys =
         originalSchema.getAllTypesAsList().stream()
             .filter(entityPredicate())
             .map(GraphQLNamedType::getName)
             .collect(Collectors.toSet());
 
     return originalSchema.getAllTypesAsList().stream()
-        .filter(entityObjectPredicate(entityTypeNames))
+        .filter(entityObjectPredicate(entitiesWithExplicitKeys))
         .map(GraphQLNamedType::getName)
         .collect(Collectors.toSet());
   }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.apollographql.federation.graphqljava.data.Product;
 import graphql.ExecutionResult;
 import graphql.Scalars;
 import graphql.com.google.common.collect.ImmutableMap;

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaTransformerTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/SchemaTransformerTest.java
@@ -1,0 +1,95 @@
+package com.apollographql.federation.graphqljava;
+
+import graphql.Scalars;
+import graphql.schema.GraphQLAppliedDirectiveArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SchemaTransformerTest {
+
+  private final GraphQLSchema TEST_SCHEMA =
+      GraphQLSchema.newSchema()
+          .query(
+              GraphQLObjectType.newObject()
+                  .name("Query")
+                  .field(
+                      GraphQLFieldDefinition.newFieldDefinition()
+                          .name("helloWorld")
+                          .type(Scalars.GraphQLString)
+                          .build()))
+          .build();
+
+  private final GraphQLObjectType FOO_TYPE =
+      GraphQLObjectType.newObject()
+          .name("Foo")
+          .field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name("id")
+                  .type(Scalars.GraphQLID)
+                  .build())
+          .build();
+
+  @Test
+  public void getFederatedEntities_entityHasAppliedDirective_found() {
+    final GraphQLSchema schema =
+        TEST_SCHEMA.transform(
+            schemaBuilder ->
+                schemaBuilder.additionalType(
+                    FOO_TYPE.transform(
+                        objectBuilder ->
+                            objectBuilder.withAppliedDirective(
+                                FederationDirectives.key
+                                    .toAppliedDirective()
+                                    .transform(
+                                        directive ->
+                                            directive.argument(
+                                                GraphQLAppliedDirectiveArgument.newArgument()
+                                                    .name("fields")
+                                                    .type(GraphQLNonNull.nonNull(_FieldSet.type))
+                                                    .valueProgrammatic("id")
+                                                    .build()))))));
+
+    final SchemaTransformer transformer = new SchemaTransformer(schema, false);
+    Set<String> entities = transformer.getFederatedEntities();
+
+    Assertions.assertFalse(entities.isEmpty());
+    Assertions.assertEquals(1, entities.size());
+    Assertions.assertTrue(entities.contains("Foo"));
+  }
+
+  @Test
+  public void getFederatedEntities_entityHasDirective_found() {
+    final GraphQLSchema schema =
+        TEST_SCHEMA.transform(
+            schemaBuilder ->
+                schemaBuilder
+                    .additionalDirective(FederationDirectives.key)
+                    .additionalType(
+                        FOO_TYPE.transform(
+                            objectBuilder ->
+                                objectBuilder.withDirective(FederationDirectives.key("id")))));
+
+    final SchemaTransformer transformer = new SchemaTransformer(schema, false);
+    Set<String> entities = transformer.getFederatedEntities();
+
+    Assertions.assertFalse(entities.isEmpty());
+    Assertions.assertEquals(1, entities.size());
+    Assertions.assertTrue(entities.contains("Foo"));
+  }
+
+  @Test
+  public void getFederatedEntities_noEntities_notFound() {
+    final GraphQLSchema schema =
+        TEST_SCHEMA.transform(schemaBuilder -> schemaBuilder.additionalType(FOO_TYPE));
+
+    final SchemaTransformer transformer = new SchemaTransformer(schema, false);
+    Set<String> entities = transformer.getFederatedEntities();
+
+    Assertions.assertTrue(entities.isEmpty());
+  }
+}

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/TestUtils.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/TestUtils.java
@@ -5,11 +5,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
-final class TestUtils {
+public final class TestUtils {
 
   private static final String BASE_LINE_SEPARATOR = "\n";
 
-  static String readResource(String name) {
+  public static String readResource(String name) {
     InputStream is = SchemaUtils.class.getResourceAsStream(name);
     assert is != null;
     BufferedReader reader = new BufferedReader(new InputStreamReader(is));

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
@@ -1,9 +1,10 @@
-package com.apollographql.federation.graphqljava;
+package com.apollographql.federation.graphqljava.caching;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.apollographql.federation.graphqljava.caching.CacheControlInstrumentation;
+import com.apollographql.federation.graphqljava.Federation;
+import com.apollographql.federation.graphqljava._Entity;
 import graphql.ExecutionInput;
 import graphql.GraphQL;
 import graphql.GraphQLContext;
@@ -11,7 +12,11 @@ import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.idl.*;
+import graphql.schema.idl.FieldWiringEnvironment;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.WiringFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/data/Product.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/data/Product.java
@@ -1,10 +1,10 @@
-package com.apollographql.federation.graphqljava;
+package com.apollographql.federation.graphqljava.data;
 
 import java.util.Objects;
 
 @SuppressWarnings("WeakerAccess")
-class Product {
-  static final Product PLANCK = new Product("PLANCK", "P", "Planck", 180);
+public class Product {
+  public static final Product PLANCK = new Product("PLANCK", "P", "Planck", 180);
 
   private final String upc;
   private final String sku;

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentationTest.java
@@ -1,4 +1,4 @@
-package com.apollographql.federation.graphqljava;
+package com.apollographql.federation.graphqljava.tracing;
 
 import static com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation.FEDERATED_TRACING_HEADER_NAME;
 import static com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation.FEDERATED_TRACING_HEADER_VALUE;
@@ -8,8 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation;
-import com.apollographql.federation.graphqljava.tracing.HTTPRequestHeaders;
+import com.apollographql.federation.graphqljava.TestUtils;
 import com.google.protobuf.InvalidProtocolBufferException;
 import graphql.ExecutionInput;
 import graphql.GraphQL;


### PR DESCRIPTION
Starting with v18, `graphql-java` makes a distinction between directive definition (`GraphQLDirective`) and its specific applied value (`GraphQLAppliedDirective`). `SchemaTransformer` was only looking for old deprecated directive information on the types when looking for entities.

Updated entity lookup logic to look at both old deprecated directive information AND new applied directive information.

Resolves: https://github.com/apollographql/federation-jvm/issues/213