### PR TITLE
use GraphQLAppliedDirective instead of GraphQLDirective for printing FederationSDL

### DIFF
--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/directiveFederated.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/directiveFederated.graphql
@@ -1,0 +1,16 @@
+union _Entity = Test
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service
+}
+
+type Test @key(fields : "dummy") {
+  dummy: String
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any

--- a/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/directiveFederatedService.graphql
+++ b/graphql-java-support/src/test/resources/com/apollographql/federation/graphqljava/schemas/directiveFederatedService.graphql
@@ -1,0 +1,9 @@
+schema {
+  query: Query
+}
+
+type Query
+
+type Test @key(fields : "dummy") {
+  dummy: String
+}


### PR DESCRIPTION
Latest graphql-java is reimplementing directives https://github.com/graphql-java/graphql-java/pull/2562 and moving to GraphQLAppliedDirective instead. 
Similarly, graphql-java-kickstart project is being updated to make use of GraphQLAppliedDirective too https://github.com/graphql-java-kickstart/graphql-java-tools/pull/663 . 
This breaks federation, as the schema built with the latest graphql-java-tools would not contain any GraphQLDirective and therefore generated SDL is going to have all of the federation-related directives missing. 
This PR is meant to address it by getting FedarationSdlPrinter to use the new directive classes everywhere, except where the actual directive definition is printed.