### PR TITLE
fix Import scalar namespace

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -373,7 +373,6 @@ public final class Federation {
                 Collectors.toMap(
                     Map.Entry::getKey, Map.Entry::getValue, (value1, value2) -> value2));
 
-    // Add hardcoded @link to avoid having federation__link all over the place
     imports.put("@link", "@link");
     return imports;
   }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/LinkImportsRenamingVisitor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/LinkImportsRenamingVisitor.java
@@ -78,6 +78,8 @@ class LinkImportsRenamingVisitor extends NodeVisitorStub {
     } else {
       if (name.equals("inaccessible") || name.equals("tag")) {
         return name;
+      } else if (name.equals("Import")) {
+        return "link__" + name;
       } else {
         // apply default namespace
         return "federation__" + name;

--- a/graphql-java-support/src/test/resources/schemas/federationV2_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/federationV2_federated.graphql
@@ -12,7 +12,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [federation__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @override(from: String!) on FIELD_DEFINITION
 
@@ -64,4 +64,4 @@ scalar _Any
 
 scalar federation__FieldSet
 
-scalar federation__Import
+scalar link__Import

--- a/graphql-java-support/src/test/resources/schemas/polymorphicSubgraph_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/polymorphicSubgraph_federated.graphql
@@ -18,7 +18,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [federation__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -55,4 +55,4 @@ scalar _Any
 
 scalar federation__FieldSet
 
-scalar federation__Import
+scalar link__Import


### PR DESCRIPTION
`@link` directive can be used to import various definitions by specifying `import: [Import]` parameter. `Import` is custom scalar that can either be a String or an Object (that allows to rename the imported type).

`Import` scalar was imported with incorrect namespace as `federation__Import` vs the expected `link__Import`. Updating transformation logic to correctly namespace the scalar. Namespace can be skipped if `Import` scalar is imported from the `@link` spec.