### PR TITLE
ServiceSDLPrinter update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.apollographql.federation
-version =2.0.2-SNAPSHOT
+version = 2.0-SNAPSHOT
 
 # dependencies
 annotationsVersion = 23.0.0

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Entity.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public final class _Entity {
   public static final String argumentName = "representations";
   public static final String typeName = "_Entity";
-  static final String fieldName = "_entities";
+  public static final String fieldName = "_entities";
 
   private _Entity() {}
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Service.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/_Service.java
@@ -10,7 +10,7 @@ import graphql.schema.GraphQLObjectType;
 
 public final class _Service {
   public static final String typeName = "_Service";
-  static final String fieldName = "_service";
+  public static final String fieldName = "_service";
   static final String sdlFieldName = "sdl";
 
   static final GraphQLObjectType type =

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/printer/ServiceSDLPrinter.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/printer/ServiceSDLPrinter.java
@@ -72,8 +72,8 @@ public final class ServiceSDLPrinter {
                 return fieldsContainer.getFieldDefinitions().stream()
                     .filter(
                         (field) ->
-                            !"_service".equals(field.getName())
-                                && !"_entities".equals(field.getName()))
+                            !_Service.fieldName.equals(field.getName())
+                                && !_Entity.fieldName.equals(field.getName()))
                     .collect(Collectors.toList());
               }
             } else {
@@ -86,8 +86,8 @@ public final class ServiceSDLPrinter {
               GraphQLFieldsContainer fieldsContainer, String fieldName) {
             if (fieldsContainer.getName().equals(queryTypeName)
                 && (queryTypeShouldBeEmpty
-                    || "_service".equals(fieldName)
-                    || "_entities".equals(fieldName))) {
+                    || _Service.fieldName.equals(fieldName)
+                    || _Entity.fieldName.equals(fieldName))) {
               return null;
             } else {
               return oldFieldVisibility.getFieldDefinition(fieldsContainer, fieldName);


### PR DESCRIPTION
`ServiceSDLPrinter` should exclude `_service` and `_entities` queries from generated SDL when transforming Federation v1 schemas.