### PR TITLE
add support for federation v2.1

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
@@ -1,0 +1,140 @@
+package com.apollographql.federation.graphqljava.directives;
+
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_1;
+import static com.apollographql.federation.graphqljava.FederationDirectives.loadFederationSpecDefinitions;
+
+import com.apollographql.federation.graphqljava.exceptions.MultipleFederationLinksException;
+import com.apollographql.federation.graphqljava.exceptions.UnsupportedLinkImportException;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.AstTransformer;
+import graphql.language.Directive;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.SDLNamedDefinition;
+import graphql.language.SchemaDefinition;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.Nullable;
+
+public final class LinkDirectiveProcessor {
+
+  private LinkDirectiveProcessor() {}
+
+  /**
+   * Load all Federation V2 definitions based on the `@link` imports.
+   *
+   * @param typeDefinitionRegistry
+   * @return Stream of Federation V2 SDLNamedDefinitions
+   * @throws MultipleFederationLinksException if schema contains multiple `@link` directives
+   *     importing federation specification
+   */
+  public static @Nullable Stream<SDLNamedDefinition> loadFederationImportedDefinitions(
+      TypeDefinitionRegistry typeDefinitionRegistry) {
+    List<Directive> federationLinkDirectives =
+        typeDefinitionRegistry
+            .schemaDefinition()
+            .map(LinkDirectiveProcessor::getFederationLinkDirectives)
+            .orElseGet(
+                () ->
+                    typeDefinitionRegistry.getSchemaExtensionDefinitions().stream()
+                        .flatMap(LinkDirectiveProcessor::getFederationLinkDirectives))
+            .collect(Collectors.toList());
+
+    if (federationLinkDirectives.isEmpty()) {
+      return null;
+    } else if (federationLinkDirectives.size() > 1) {
+      throw new MultipleFederationLinksException(federationLinkDirectives);
+    } else {
+      return loadDefinitions(federationLinkDirectives.get(0));
+    }
+  }
+
+  private static Stream<SDLNamedDefinition> loadDefinitions(Directive linkDirective) {
+    final Map<String, String> imports = parseLinkImports(linkDirective);
+
+    final Argument urlArgument = linkDirective.getArgument("url");
+    final String specLink = ((StringValue) urlArgument.getValue()).getValue();
+    final boolean allowComposeableDirective = FEDERATION_SPEC_V2_1.equals(specLink);
+
+    if (!allowComposeableDirective && imports.containsKey("@composeDirective")) {
+      throw new UnsupportedLinkImportException("@composeDirective");
+    }
+
+    return loadFederationSpecDefinitions(specLink).stream()
+        .map(
+            definition ->
+                (SDLNamedDefinition)
+                    new AstTransformer()
+                        .transform(definition, new LinkImportsRenamingVisitor(imports)));
+  }
+
+  private static Stream<Directive> getFederationLinkDirectives(SchemaDefinition schemaDefinition) {
+    return schemaDefinition.getDirectives("link").stream()
+        .filter(
+            directive -> {
+              Argument urlArgument = directive.getArgument("url");
+              if (urlArgument != null && urlArgument.getValue() instanceof StringValue) {
+                StringValue value = (StringValue) urlArgument.getValue();
+                return value.getValue().startsWith("https://specs.apollo.dev/federation/");
+              } else {
+                return false;
+              }
+            });
+  }
+
+  private static Map<String, String> parseLinkImports(Directive linkDirective) {
+    final Map<String, String> imports = new HashMap<>();
+
+    final Argument importArgument = linkDirective.getArgument("import");
+    if (importArgument != null && importArgument.getValue() instanceof ArrayValue) {
+      final ArrayValue linkImports = (ArrayValue) importArgument.getValue();
+      for (Value importedDefinition : linkImports.getValues()) {
+        if (importedDefinition instanceof StringValue) {
+          // no rename
+          final String name = ((StringValue) importedDefinition).getValue();
+          imports.put(name, name);
+        } else if (importedDefinition instanceof ObjectValue) {
+          // renamed import
+          final ObjectValue importedObjectValue = (ObjectValue) importedDefinition;
+
+          final Optional<ObjectField> nameField =
+              importedObjectValue.getObjectFields().stream()
+                  .filter(field -> field.getName().equals("name"))
+                  .findFirst();
+          final Optional<ObjectField> renameAsField =
+              importedObjectValue.getObjectFields().stream()
+                  .filter(field -> field.getName().equals("as"))
+                  .findFirst();
+
+          if (!nameField.isPresent() || !(nameField.get().getValue() instanceof StringValue)) {
+            throw new UnsupportedLinkImportException(importedObjectValue);
+          }
+          final String name = ((StringValue) nameField.get().getValue()).getValue();
+
+          if (!renameAsField.isPresent()) {
+            imports.put(name, name);
+          } else {
+            final Value renamedAsValue = renameAsField.get().getValue();
+            if (!(renamedAsValue instanceof StringValue)) {
+              throw new UnsupportedLinkImportException(importedObjectValue);
+            }
+            imports.put(name, ((StringValue) renamedAsValue).getValue());
+          }
+        } else {
+          throw new UnsupportedLinkImportException(importedDefinition);
+        }
+      }
+    }
+
+    imports.put("@link", "@link");
+    return imports;
+  }
+}

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkImportsRenamingVisitor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkImportsRenamingVisitor.java
@@ -1,7 +1,8 @@
-package com.apollographql.federation.graphqljava;
+package com.apollographql.federation.graphqljava.directives;
 
 import static graphql.util.TreeTransformerUtil.changeNode;
 
+import com.apollographql.federation.graphqljava.exceptions.UnsupportedRenameException;
 import graphql.language.DirectiveDefinition;
 import graphql.language.NamedNode;
 import graphql.language.Node;
@@ -66,8 +67,7 @@ class LinkImportsRenamingVisitor extends NodeVisitorStub {
     if (fed2Imports.containsKey(key)) {
       String newName = fed2Imports.get(key);
       if (("@tag".equals(key) || "@inaccessible".equals(key)) && !newName.equals(key)) {
-        throw new FederationError(
-            "Current version of Apollo Federation does not allow renaming " + key + " directive.");
+        throw new UnsupportedRenameException(key);
       }
 
       if (isDirective) {

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/MultipleFederationLinksException.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/MultipleFederationLinksException.java
@@ -1,0 +1,15 @@
+package com.apollographql.federation.graphqljava.exceptions;
+
+import graphql.language.Directive;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Exception thrown when schema defines multiple `@link` directives importing federation spec. */
+public class MultipleFederationLinksException extends RuntimeException {
+
+  public MultipleFederationLinksException(List<Directive> directives) {
+    super(
+        "Schema imports multiple federation specs: "
+            + directives.stream().map(Directive::toString).collect(Collectors.joining()));
+  }
+}

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedFederationVersionException.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedFederationVersionException.java
@@ -1,0 +1,8 @@
+package com.apollographql.federation.graphqljava.exceptions;
+
+/** Exception thrown while processing link that specifies currently not supported version. */
+public class UnsupportedFederationVersionException extends RuntimeException {
+  public UnsupportedFederationVersionException(String federationSpec) {
+    super("Specified federation spec = " + federationSpec + " is currently not supported");
+  }
+}

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedLinkImportException.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedLinkImportException.java
@@ -5,13 +5,19 @@ import graphql.language.Value;
 /**
  * Exception thrown when processing invalid `@link` import definitions.
  *
- * <p>Unsupported imports: - specifying object import without specifying String name - specifying
- * object rename that is not a String - attempting to import definition that is not a String nor an
- * object definition
+ * <p>Unsupported imports:<br>
+ * - specifying object import without specifying String name<br>
+ * - specifying object rename that is not a String<br>
+ * - attempting to import definition that is not a String nor an object definition<br>
+ * - attempting to import
  */
 public class UnsupportedLinkImportException extends RuntimeException {
 
   public UnsupportedLinkImportException(Value importedDefinition) {
     super("Unsupported import: " + importedDefinition);
+  }
+
+  public UnsupportedLinkImportException(String importedDefinition) {
+    super("Unsupported federation import: " + importedDefinition);
   }
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedRenameException.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedRenameException.java
@@ -1,0 +1,9 @@
+package com.apollographql.federation.graphqljava.exceptions;
+
+/** Exception thrown when attempting to rename directive imports that cannot be renamed. */
+public class UnsupportedRenameException extends RuntimeException {
+
+  public UnsupportedRenameException(String name) {
+    super("Current version of Apollo Federation does not allow renaming " + name + " directive.");
+  }
+}

--- a/graphql-java-support/src/main/resources/definitions_fed2_0.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_0.graphqls
@@ -1,5 +1,6 @@
-# Fed2 directives taken from https://github.com/apollographql/federation/blob/c68e501b4c02bd65f6b0bbbabf1b2aa4a2ab3c47/subgraph-js/src/federation-atlas.ts
-# 
+#
+# https://specs.apollo.dev/federation/v2.0/federation-v2.0.graphql
+#
 
 directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 directive @requires(fields: FieldSet!) on FIELD_DEFINITION
@@ -8,8 +9,19 @@ directive @external on OBJECT | FIELD_DEFINITION
 directive @shareable on FIELD_DEFINITION | OBJECT
 directive @extends on OBJECT | INTERFACE
 directive @override(from: String!) on FIELD_DEFINITION
-
-directive @tag(name: String!) repeatable on FIELD_DEFINITION
+directive @inaccessible on
+    | FIELD_DEFINITION
+    | OBJECT
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | SCALAR
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
     | INTERFACE
     | OBJECT
     | UNION
@@ -19,11 +31,16 @@ directive @tag(name: String!) repeatable on FIELD_DEFINITION
     | ENUM_VALUE
     | INPUT_OBJECT
     | INPUT_FIELD_DEFINITION
-
-directive @inaccessible on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
 scalar FieldSet
 
-directive @link(url: String!, as: String, import: [Import]) repeatable on SCHEMA
+#
+# https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
+#
+
+directive @link(
+    url: String!,
+    as: String,
+    import: [Import])
+repeatable on SCHEMA
 
 scalar Import

--- a/graphql-java-support/src/main/resources/definitions_fed2_1.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_1.graphqls
@@ -1,0 +1,52 @@
+#
+# https://specs.apollo.dev/federation/v2.0/federation-v2.0.graphql
+#
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @extends on OBJECT | INTERFACE
+directive @override(from: String!) on FIELD_DEFINITION
+directive @inaccessible on
+    | FIELD_DEFINITION
+    | OBJECT
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | SCALAR
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+scalar FieldSet
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+#
+# https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
+#
+
+directive @link(
+    url: String!,
+    as: String,
+    import: [Import])
+repeatable on SCHEMA
+
+scalar Import

--- a/graphql-java-support/src/test/resources/schemas/composeDirective.graphql
+++ b/graphql-java-support/src/test/resources/schemas/composeDirective.graphql
@@ -1,0 +1,19 @@
+extend schema
+@link(url: "https://specs.apollo.dev/federation/v2.1",
+    import: ["@key", "@composeDirective"])
+@link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }])
+@composeDirective(name: "@myDirective")
+@composeDirective(name: "@hello")
+
+directive @myDirective(foo: String!) on FIELD_DEFINITION
+directive @hello on FIELD_DEFINITION
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String! @hello
+    custom: String @myDirective(foo: "bar")
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/composeDirectiveUnsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/composeDirectiveUnsupportedSpecVersion.graphql
@@ -1,0 +1,19 @@
+extend schema
+@link(url: "https://specs.apollo.dev/federation/v2.0",
+    import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@composeDirective"])
+@link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }])
+@composeDirective(name: "@myDirective")
+@composeDirective(name: "@hello")
+
+directive @myDirective(foo: String!) on FIELD_DEFINITION
+directive @hello on FIELD_DEFINITION
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String! @hello
+    custom: String @myDirective(foo: "bar")
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/composeDirective_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/composeDirective_federated.graphql
@@ -1,0 +1,53 @@
+schema @composeDirective(name : "@myDirective") @composeDirective(name : "@hello") @link(import : ["@key", "@composeDirective"], url : "https://specs.apollo.dev/federation/v2.1") @link(import : ["@myDirective", {name : "@anotherDirective", as : "@hello"}], url : "https://myspecs.dev/myDirective/v1.0"){
+  query: Query
+}
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__external on OBJECT | FIELD_DEFINITION
+
+directive @federation__override(from: String!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @hello on FIELD_DEFINITION
+
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+
+directive @myDirective(foo: String!) on FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+union _Entity = Product
+
+type Product @key(fields : "id", resolvable : true) {
+  custom: String @myDirective(foo : "bar")
+  id: ID!
+  name: String! @hello
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  product(id: ID!): Product
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+scalar federation__FieldSet
+
+scalar link__Import

--- a/graphql-java-support/src/test/resources/schemas/multipleLinks.graphql
+++ b/graphql-java-support/src/test/resources/schemas/multipleLinks.graphql
@@ -1,0 +1,21 @@
+extend schema
+@link(url: "https://specs.apollo.dev/federation/v2.0",
+    import: ["@key"])
+@link(url: "https://specs.apollo.dev/federation/v2.1",
+  import: ["@composeDirective"])
+@link(url: "https://myspecs.dev/myDirective/v1.0", import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }])
+@composeDirective(name: "@myDirective")
+@composeDirective(name: "@hello")
+
+directive @myDirective(foo: String!) on FIELD_DEFINITION
+directive @hello on FIELD_DEFINITION
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String! @hello
+    custom: String @myDirective(foo: "bar")
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/unsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/unsupportedSpecVersion.graphql
@@ -1,0 +1,13 @@
+extend schema
+@link(url: "https://specs.apollo.dev/federation/v99.99",
+    import: ["@key"])
+
+type Product @key(fields: "id") {
+    id: ID!
+    package: String
+    notes: String @tag(name: "internal")
+}
+
+type Query {
+    product(id: ID!): Product
+}


### PR DESCRIPTION
Add support for latest Federation spec versions and improve validation logic. See [Federation documentation](https://www.apollographql.com/docs/federation/) for additional details.

Federation v2.1 features:

* support new `@composeDirective`

New validations:

* Multiple `@link` imports of federation spec are no longer valid.
* Attempting to import `@composeDirective` from Fed v2.0 spec will throw validation exception.
* Attempting to rename `@tag`/`@inaccessible` now throws more specific exception
* Validating federation spec version