### PR TITLE
chore: remove unused property from build script

### DIFF
--- a/graphql-java-support/build.gradle.kts
+++ b/graphql-java-support/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 val annotationsVersion: String by project
 val graphQLJavaVersion: String by project
-val junitVersion: String by project
 val protobufVersion: String by project
 val slf4jVersion: String by project
 dependencies {


### PR DESCRIPTION
The property `junitVersion` in the Gradle build script of the `graphql-java-support-build` and can be removed.