### PR TITLE
add support for Federation v2.2

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -28,6 +28,8 @@ public final class Federation {
   public static final String FEDERATION_SPEC_V2_0 = "https://specs.apollo.dev/federation/v2.0";
   public static final String FEDERATION_SPEC_V2_1 = "https://specs.apollo.dev/federation/v2.1";
 
+  public static final String FEDERATION_SPEC_V2_2 = "https://specs.apollo.dev/federation/v2.2";
+
   private static final SchemaGenerator.Options generatorOptions =
       SchemaGenerator.Options.defaultOptions();
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -2,6 +2,7 @@ package com.apollographql.federation.graphqljava;
 
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_0;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_1;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_2;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
 import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
@@ -201,6 +202,8 @@ public final class FederationDirectives {
         return loadFed2Definitions("definitions_fed2_0.graphqls");
       case FEDERATION_SPEC_V2_1:
         return loadFed2Definitions("definitions_fed2_1.graphqls");
+      case FEDERATION_SPEC_V2_2:
+        return loadFed2Definitions("definitions_fed2_2.graphqls");
       default:
         throw new UnsupportedFederationVersionException(federationSpec);
     }

--- a/graphql-java-support/src/main/resources/definitions_fed2_2.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_2.graphqls
@@ -1,0 +1,57 @@
+#
+# https://specs.apollo.dev/federation/v2.0/federation-v2.0.graphql
+#
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
+directive @extends on OBJECT | INTERFACE
+directive @override(from: String!) on FIELD_DEFINITION
+directive @inaccessible on
+    | FIELD_DEFINITION
+    | OBJECT
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | SCALAR
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+scalar FieldSet
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+#
+# https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
+#
+
+directive @link(
+    url: String!,
+    as: String,
+    import: [Import])
+repeatable on SCHEMA
+
+scalar Import
+
+#
+# federation-v2.2
+#
+
+directive @shareable repeatable on FIELD_DEFINITION | OBJECT

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -24,6 +24,7 @@ import graphql.schema.TypeResolver;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.TypeRuntimeWiring;
 import graphql.schema.idl.errors.SchemaProblem;
+import graphql.schema.validation.InvalidSchemaException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -205,7 +206,7 @@ class FederationTest {
   }
 
   @Test
-  public void verifyFederationTransformation_composeDirective() {
+  public void verifyFederationV2Transformation_composeDirective() {
     verifyFederationTransformation("schemas/composeDirective.graphql", true);
   }
 
@@ -247,6 +248,26 @@ class FederationTest {
     assertThrows(
         MultipleFederationLinksException.class,
         () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
+  }
+
+  @Test
+  public void verifyFederationV2Transformation_repeatableShareable() {
+    verifyFederationTransformation("schemas/repeatableShareable.graphql", true);
+  }
+
+  @Test
+  public void
+      verifyFederationV2Transformation_repeatableShareableFromUnsupportedVersion_throwsException() {
+    final String schemaSDL =
+        FileUtils.readResource("schemas/repeatableShareableUnsupportedVersion.graphql");
+    assertThrows(
+        InvalidSchemaException.class,
+        () ->
+            Federation.transform(schemaSDL)
+                .fetchEntities(env -> null)
+                .resolveEntityType(env -> null)
+                .build(),
+        "The directive 'shareable' on the 'GraphQLObjectType' called 'Position' is a non repeatable directive but has been applied 2 times");
   }
 
   private GraphQLSchema verifyFederationTransformation(

--- a/graphql-java-support/src/test/resources/schemas/repeatableShareable.graphql
+++ b/graphql-java-support/src/test/resources/schemas/repeatableShareable.graphql
@@ -1,0 +1,20 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.2", import: ["@key", "@shareable"])
+
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  position: Position
+}
+
+type Position @shareable {
+  x: Float!
+  y: Float!
+}
+
+extend type Position @shareable {
+  z: Float!
+}
+
+type Query {
+  product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/repeatableShareableUnsupportedVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/repeatableShareableUnsupportedVersion.graphql
@@ -1,0 +1,20 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@shareable"])
+
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  position: Position
+}
+
+type Position @shareable {
+  x: Float!
+  y: Float!
+}
+
+extend type Position @shareable {
+  z: Float!
+}
+
+type Query {
+  product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/repeatableShareable_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/repeatableShareable_federated.graphql
@@ -1,0 +1,55 @@
+schema @link(import : ["@key", "@shareable"], url : "https://specs.apollo.dev/federation/v2.2"){
+  query: Query
+}
+
+directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__external on OBJECT | FIELD_DEFINITION
+
+directive @federation__override(from: String!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+union _Entity = Product
+
+type Position @shareable @shareable {
+  x: Float!
+  y: Float!
+  z: Float!
+}
+
+type Product @key(fields : "id", resolvable : true) {
+  id: ID!
+  name: String!
+  position: Position
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  product(id: ID!): Product
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+scalar federation__FieldSet
+
+scalar link__Import


### PR DESCRIPTION
Federation v2.2 makes `@shareable` directive repeatable.

```graphql
directive @shareable repeatable on FIELD_DEFINITION | OBJECT
```

This allows usage of the directive on the type extensions to make new fields also shareable:

```graphql
type Position @shareable {
  x: Int!
  y: Int!
}

extend type Position @shareable {
  z: Int!
}
```

See [docs for more info](https://www.apollographql.com/docs/federation/federated-types/sharing-types#span-roleimg-aria-labelmemospan-a-note-regarding-shareable-on-types)