### PR TITLE
add support for Federation v2.3

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -30,6 +30,8 @@ public final class Federation {
 
   public static final String FEDERATION_SPEC_V2_2 = "https://specs.apollo.dev/federation/v2.2";
 
+  public static final String FEDERATION_SPEC_V2_3 = "https://specs.apollo.dev/federation/v2.3";
+
   private static final SchemaGenerator.Options generatorOptions =
       SchemaGenerator.Options.defaultOptions();
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -3,6 +3,7 @@ package com.apollographql.federation.graphqljava;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_0;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_1;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_2;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_3;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
 import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
@@ -204,6 +205,8 @@ public final class FederationDirectives {
         return loadFed2Definitions("definitions_fed2_1.graphqls");
       case FEDERATION_SPEC_V2_2:
         return loadFed2Definitions("definitions_fed2_2.graphqls");
+      case FEDERATION_SPEC_V2_3:
+        return loadFed2Definitions("definitions_fed2_3.graphqls");
       default:
         throw new UnsupportedFederationVersionException(federationSpec);
     }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
@@ -1,6 +1,7 @@
 package com.apollographql.federation.graphqljava.directives;
 
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_1;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_3;
 import static com.apollographql.federation.graphqljava.FederationDirectives.loadFederationSpecDefinitions;
 
 import com.apollographql.federation.graphqljava.exceptions.MultipleFederationLinksException;
@@ -67,9 +68,14 @@ public final class LinkDirectiveProcessor {
     final Argument urlArgument = linkDirective.getArgument("url");
     final String specLink = ((StringValue) urlArgument.getValue()).getValue();
     final boolean allowComposeableDirective = FEDERATION_SPEC_V2_1.equals(specLink);
+    final boolean allowInterfaceObjectDirective = FEDERATION_SPEC_V2_3.equals(specLink);
 
     if (!allowComposeableDirective && imports.containsKey("@composeDirective")) {
       throw new UnsupportedLinkImportException("@composeDirective");
+    }
+
+    if (!allowInterfaceObjectDirective && imports.containsKey("@interfaceObject")) {
+      throw new UnsupportedLinkImportException("@interfaceObject");
     }
 
     return loadFederationSpecDefinitions(specLink).stream()

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedLinkImportException.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedLinkImportException.java
@@ -18,6 +18,7 @@ public class UnsupportedLinkImportException extends RuntimeException {
   }
 
   public UnsupportedLinkImportException(String importedDefinition) {
-    super("Unsupported federation import: " + importedDefinition);
+    super(
+        "New Federation feature " + importedDefinition + " imported using old Federation version");
   }
 }

--- a/graphql-java-support/src/main/resources/definitions_fed2_3.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_3.graphqls
@@ -1,0 +1,63 @@
+#
+# https://specs.apollo.dev/federation/v2.0/federation-v2.0.graphql
+#
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
+directive @extends on OBJECT | INTERFACE
+directive @override(from: String!) on FIELD_DEFINITION
+directive @inaccessible on
+    | FIELD_DEFINITION
+    | OBJECT
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | SCALAR
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+scalar FieldSet
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+#
+# https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
+#
+
+directive @link(
+    url: String!,
+    as: String,
+    import: [Import])
+repeatable on SCHEMA
+
+scalar Import
+
+#
+# federation-v2.2
+#
+
+directive @shareable repeatable on FIELD_DEFINITION | OBJECT
+
+#
+# federation-v2.3
+#
+
+directive @interfaceObject on OBJECT

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -270,6 +270,26 @@ class FederationTest {
         "The directive 'shareable' on the 'GraphQLObjectType' called 'Position' is a non repeatable directive but has been applied 2 times");
   }
 
+  @Test
+  public void verifyFederationV2Transformation_interfaceObject() {
+    verifyFederationTransformation("schemas/interfaceObject.graphql", true);
+  }
+
+  @Test
+  public void
+      verifyFederationV2Transformation_interfaceObjectFromUnsupportedVersion_throwsException() {
+    final String schemaSDL =
+        FileUtils.readResource("schemas/interfaceObjectUnsupportedVersion.graphql");
+    assertThrows(
+        UnsupportedLinkImportException.class,
+        () ->
+            Federation.transform(schemaSDL)
+                .fetchEntities(env -> null)
+                .resolveEntityType(env -> null)
+                .build(),
+        "foo");
+  }
+
   private GraphQLSchema verifyFederationTransformation(
       String schemaFileName, boolean isFederationV2) {
     final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();

--- a/graphql-java-support/src/test/resources/schemas/interfaceObject.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObject.graphql
@@ -1,0 +1,10 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key", "@interfaceObject"])
+
+type Product @key(fields: "id") @interfaceObject {
+    id: ID!
+    name: String!
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/interfaceObjectUnsupportedVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObjectUnsupportedVersion.graphql
@@ -1,0 +1,10 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@interfaceObject"])
+
+type Product @key(fields: "id") @interfaceObject {
+    id: ID!
+    name: String!
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/interfaceObject_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObject_federated.graphql
@@ -1,0 +1,50 @@
+schema @link(import : ["@key", "@interfaceObject"], url : "https://specs.apollo.dev/federation/v2.3"){
+  query: Query
+}
+
+directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__external on OBJECT | FIELD_DEFINITION
+
+directive @federation__override(from: String!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @interfaceObject on OBJECT
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+union _Entity = Product
+
+type Product @interfaceObject @key(fields : "id", resolvable : true) {
+  id: ID!
+  name: String!
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  product(id: ID!): Product
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+scalar federation__FieldSet
+
+scalar link__Import


### PR DESCRIPTION
Adds support for Federation v2.3 which introduces new `@interfaceObject` directive.

```graphql
directive @interfaceObject on OBJECT
```

New directive enables usage of `@key` directive on interface definitions. This allows interfaces to be treated as entities and extended across subgraphs (vs extending each and every implementation).

Example:

Given following `products` subgraph

```graphql
type Query {
  products: [Product!]!
}

interface Product {
  id: ID!
  description: String
  price: Float
}

type Book implements Product @key(fields: "id") {
  id: ID!
  description: String
  price: Float
  pages: Int
}

type Movie implements Product @key(fields: "id") {
  id: ID!
  description: String
  price: Float
  duration: Int
}
```

We can then extend the `Product` interface in `reviews` subgraph as

```graphql
type Product @key(fields: "id") @interfaceObject {
  id: ID!
  reviews: [Review!]!
}

type Review {
  author: String
  text: String
  rating: Int
}
```

See: https://github.com/apollographql/federation/issues/2277