### PR TITLE
feature: auto-populate entity type resolver for non-resolvable entities

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -247,41 +247,41 @@ public final class SchemaTransformer {
 
   private boolean resolvableEntitiesExist(Set<String> entityNames) {
     return entityNames.stream()
-      .anyMatch(
-        entity -> {
-          GraphQLObjectType entityObject = (GraphQLObjectType) originalSchema.getType(entity);
-          boolean isResolvable =
-            entityObject.getAppliedDirectives(FederationDirectives.keyName).stream()
-              .anyMatch(
-                key -> {
-                  GraphQLAppliedDirectiveArgument resolvable =
-                    key.getArgument("resolvable");
-                  if (resolvable != null) {
-                    BooleanValue resolvableValue =
-                      (BooleanValue) resolvable.getArgumentValue().getValue();
-                    return resolvableValue == null || resolvableValue.isValue();
-                  } else {
-                    return true;
-                  }
-                });
+        .anyMatch(
+            entity -> {
+              GraphQLObjectType entityObject = (GraphQLObjectType) originalSchema.getType(entity);
+              boolean isResolvable =
+                  entityObject.getAppliedDirectives(FederationDirectives.keyName).stream()
+                      .anyMatch(
+                          key -> {
+                            GraphQLAppliedDirectiveArgument resolvable =
+                                key.getArgument("resolvable");
+                            if (resolvable != null) {
+                              BooleanValue resolvableValue =
+                                  (BooleanValue) resolvable.getArgumentValue().getValue();
+                              return resolvableValue == null || resolvableValue.isValue();
+                            } else {
+                              return true;
+                            }
+                          });
 
-          if (!isResolvable) {
-            // fallback to also verify old directive definitions
-            return entityObject.getDirectives(FederationDirectives.keyName).stream()
-              .anyMatch(
-                key -> {
-                  GraphQLArgument resolvable = key.getArgument("resolvable");
-                  if (resolvable != null) {
-                    BooleanValue resolvableValue =
-                      (BooleanValue) resolvable.getArgumentValue().getValue();
-                    return resolvableValue == null || resolvableValue.isValue();
-                  }
-                  return true;
-                });
-          } else {
-            return true;
-          }
-        });
+              if (!isResolvable) {
+                // fallback to also verify old directive definitions
+                return entityObject.getDirectives(FederationDirectives.keyName).stream()
+                    .anyMatch(
+                        key -> {
+                          GraphQLArgument resolvable = key.getArgument("resolvable");
+                          if (resolvable != null) {
+                            BooleanValue resolvableValue =
+                                (BooleanValue) resolvable.getArgumentValue().getValue();
+                            return resolvableValue == null || resolvableValue.isValue();
+                          }
+                          return true;
+                        });
+              } else {
+                return true;
+              }
+            });
   }
 
   /**

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -5,11 +5,14 @@ import static com.apollographql.federation.graphqljava.printer.ServiceSDLPrinter
 
 import com.apollographql.federation.graphqljava.exceptions.MissingKeyException;
 import graphql.GraphQLError;
+import graphql.language.BooleanValue;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactory;
 import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLAppliedDirectiveArgument;
+import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLDirectiveContainer;
 import graphql.schema.GraphQLInterfaceType;
@@ -73,9 +76,7 @@ public final class SchemaTransformer {
   }
 
   @NotNull
-  public final GraphQLSchema build() throws SchemaProblem {
-    final List<GraphQLError> errors = new ArrayList<>();
-
+  public GraphQLSchema build() throws SchemaProblem {
     // Make new Schema
     final GraphQLSchema.Builder newSchema = GraphQLSchema.newSchema(originalSchema);
 
@@ -98,31 +99,7 @@ public final class SchemaTransformer {
     newSchema.query(newQueryType.build());
 
     final GraphQLCodeRegistry.Builder newCodeRegistry =
-        GraphQLCodeRegistry.newCodeRegistry(originalSchema.getCodeRegistry());
-
-    if (!entityTypeNames.isEmpty()) {
-      if (entityTypeResolver != null) {
-        newCodeRegistry.typeResolver(_Entity.typeName, entityTypeResolver);
-      } else {
-        if (!newCodeRegistry.hasTypeResolver(_Entity.typeName)) {
-          errors.add(new FederationError("Missing a type resolver for _Entity"));
-        }
-      }
-
-      final FieldCoordinates _entities =
-          FieldCoordinates.coordinates(originalQueryType.getName(), _Entity.fieldName);
-      if (entitiesDataFetcher != null) {
-        newCodeRegistry.dataFetcher(_entities, entitiesDataFetcher);
-      } else if (entitiesDataFetcherFactory != null) {
-        newCodeRegistry.dataFetcher(_entities, entitiesDataFetcherFactory);
-      } else if (!newCodeRegistry.hasDataFetcher(_entities)) {
-        errors.add(new FederationError("Missing a data fetcher for _entities"));
-      }
-    }
-
-    if (!errors.isEmpty()) {
-      throw new SchemaProblem(errors);
-    }
+        updateCodeRegistryWithEntityResolvers(entityTypeNames);
 
     // expose the schema as _service.sdl
     newCodeRegistry.dataFetcher(
@@ -168,7 +145,7 @@ public final class SchemaTransformer {
         .map(type -> (GraphQLObjectType) type)
         .forEach(
             type ->
-                type.getInterfaces().stream()
+                type.getInterfaces()
                     .forEach(
                         intf -> {
                           if (interfaceEntities.contains(intf)) {
@@ -222,6 +199,91 @@ public final class SchemaTransformer {
             .collect(Collectors.toSet()));
 
     return fieldSets;
+  }
+
+  private GraphQLCodeRegistry.Builder updateCodeRegistryWithEntityResolvers(
+      Set<String> entityTypeNames) {
+    final List<GraphQLError> errors = new ArrayList<>();
+    final GraphQLCodeRegistry.Builder newCodeRegistry =
+        GraphQLCodeRegistry.newCodeRegistry(originalSchema.getCodeRegistry());
+
+    if (!entityTypeNames.isEmpty()) {
+      final boolean areEntitiesResolvable = resolvableEntitiesExist(entityTypeNames);
+      if (entityTypeResolver != null) {
+        newCodeRegistry.typeResolver(_Entity.typeName, entityTypeResolver);
+      } else if (!areEntitiesResolvable) {
+        // add fake entity union resolver as this type will never be resolved locally
+        newCodeRegistry.typeResolver(
+            _Entity.typeName,
+            env -> {
+              throw new IllegalStateException(
+                  "_Entity type resolver should never be called on non-resolvable entities");
+            });
+      } else {
+        if (!newCodeRegistry.hasTypeResolver(_Entity.typeName)) {
+          errors.add(new FederationError("Missing a type resolver for _Entity"));
+        }
+      }
+
+      if (areEntitiesResolvable) {
+        // need _entities resolver
+        final FieldCoordinates _entities =
+            FieldCoordinates.coordinates(
+                originalSchema.getQueryType().getName(), _Entity.fieldName);
+        if (entitiesDataFetcher != null) {
+          newCodeRegistry.dataFetcher(_entities, entitiesDataFetcher);
+        } else if (entitiesDataFetcherFactory != null) {
+          newCodeRegistry.dataFetcher(_entities, entitiesDataFetcherFactory);
+        } else if (!newCodeRegistry.hasDataFetcher(_entities)) {
+          errors.add(new FederationError("Missing a data fetcher for _entities"));
+        }
+      }
+    }
+
+    if (!errors.isEmpty()) {
+      throw new SchemaProblem(errors);
+    }
+
+    return newCodeRegistry;
+  }
+
+  private boolean resolvableEntitiesExist(Set<String> entityNames) {
+    return entityNames.stream()
+      .anyMatch(
+        entity -> {
+          GraphQLObjectType entityObject = (GraphQLObjectType) originalSchema.getType(entity);
+          boolean isResolvable =
+            entityObject.getAppliedDirectives(FederationDirectives.keyName).stream()
+              .anyMatch(
+                key -> {
+                  GraphQLAppliedDirectiveArgument resolvable =
+                    key.getArgument("resolvable");
+                  if (resolvable != null) {
+                    BooleanValue resolvableValue =
+                      (BooleanValue) resolvable.getArgumentValue().getValue();
+                    return resolvableValue == null || resolvableValue.isValue();
+                  } else {
+                    return true;
+                  }
+                });
+
+          if (!isResolvable) {
+            // fallback to also verify old directive definitions
+            return entityObject.getDirectives(FederationDirectives.keyName).stream()
+              .anyMatch(
+                key -> {
+                  GraphQLArgument resolvable = key.getArgument("resolvable");
+                  if (resolvable != null) {
+                    BooleanValue resolvableValue =
+                      (BooleanValue) resolvable.getArgumentValue().getValue();
+                    return resolvableValue == null || resolvableValue.isValue();
+                  }
+                  return true;
+                });
+          } else {
+            return true;
+          }
+        });
   }
 
   /**

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -219,10 +219,8 @@ public final class SchemaTransformer {
               throw new IllegalStateException(
                   "_Entity type resolver should never be called on non-resolvable entities");
             });
-      } else {
-        if (!newCodeRegistry.hasTypeResolver(_Entity.typeName)) {
-          errors.add(new FederationError("Missing a type resolver for _Entity"));
-        }
+      } else if (!newCodeRegistry.hasTypeResolver(_Entity.typeName)) {
+        errors.add(new FederationError("Missing a type resolver for _Entity"));
       }
 
       if (areEntitiesResolvable) {

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -286,6 +286,19 @@ class FederationTest {
     verifyFederationTransformation("schemas/interfaceEntity.graphql", runtimeWiring, true);
   }
 
+  @Test
+  public void verifyFederationV2Transformation_nonResolvableKey_doesNotRequireResolvers() {
+    final String originalSDL = FileUtils.readResource("schemas/nonResolvableKey.graphql");
+    final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
+    final GraphQLSchema federatedSchema = Federation.transform(originalSDL, runtimeWiring).build();
+
+    final String expectedFederatedSchemaSDL =
+        FileUtils.readResource("schemas/nonResolvableKey_federated.graphql");
+    FederatedSchemaVerifier.verifySchemaSDL(federatedSchema, expectedFederatedSchemaSDL, true);
+    FederatedSchemaVerifier.verifySchemaContainsServiceFederationType(federatedSchema);
+    FederatedSchemaVerifier.verifyServiceSDL(federatedSchema, expectedFederatedSchemaSDL);
+  }
+
   private GraphQLSchema verifyFederationTransformation(
       String schemaFileName, boolean isFederationV2) {
     final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();

--- a/graphql-java-support/src/test/resources/schemas/nonResolvableKey.graphql
+++ b/graphql-java-support/src/test/resources/schemas/nonResolvableKey.graphql
@@ -1,0 +1,15 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+
+type Product {
+  id: ID!
+  description: String!
+  createdBy: User
+}
+
+type Query {
+  product(id: ID!): Product
+}
+
+type User @key(fields: "email", resolvable: false) {
+  email: ID!
+}

--- a/graphql-java-support/src/test/resources/schemas/nonResolvableKey_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/nonResolvableKey_federated.graphql
@@ -1,0 +1,55 @@
+schema @link(import : ["@key"], url : "https://specs.apollo.dev/federation/v2.3"){
+  query: Query
+}
+
+directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__external on OBJECT | FIELD_DEFINITION
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__override(from: String!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+union _Entity = User
+
+type Product {
+  createdBy: User
+  description: String!
+  id: ID!
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  product(id: ID!): Product
+}
+
+type User @key(fields : "email", resolvable : false) {
+  email: ID!
+}
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+scalar federation__FieldSet
+
+scalar link__Import


### PR DESCRIPTION
Whenever all entites are non-resolvable locally (i.e. `@key` specifies `resolvable:false`), then corresponding resolvers should never be invoked locally and users shouldn't have to specify fake ones.

Changes:
* default fake `_Entity` type resolver will be automatically created if it is not provided and all entities are non-resolvable
* default fake `_Entity` type resolver will throw `IllegalStateException` if invoked at runtime
* `_entities` data fetcher does not have to be specified if all entities are non-resolvable

Related:
* Resolves #70 