### PR TITLE
deprecate HTTPRequestHeaders tracing mechanism

### DIFF
--- a/graphql-java-support-api/src/main/java/com/apollographql/federation/graphqljava/tracing/HTTPRequestHeaders.java
+++ b/graphql-java-support-api/src/main/java/com/apollographql/federation/graphqljava/tracing/HTTPRequestHeaders.java
@@ -6,7 +6,11 @@ import org.jetbrains.annotations.Nullable;
  * If the context object on your GraphQL ExecutionInput implements this interface,
  * FederationTracingInstrumentation will generate traces only when requested to by the gateway in
  * front of it.
+ *
+ * @deprecated HTTPRequestHeaders relies on old deprecated GraphQL context mechanism. Migrate to use
+ * new generic context map mechanism which should include ftv1 entry.
  */
+@Deprecated
 public interface HTTPRequestHeaders {
   /**
    * Return the value of the given HTTP header from the request, or null if the header is not


### PR DESCRIPTION
Starting with `graphql-java` 17 new generic context map is the default mechanism for storing and propagating GraphQL context. `HTTPRequestHeaders` rely on old deprecated mechanism that will be removed in future versions of `graphql-java`.

Instead of implementing custom GraphQL context object that implements this interface, users should populate ftv entry directly in the new context map

```java
String federatedTracingHeaderValue = httpRequest.getHeader(FEDERATED_TRACING_HEADER_NAME);

Map<Object, Object> contextMap = new HashMap<>();
contextMap.put(FEDERATED_TRACING_HEADER_NAME, federatedTracingHeaderValue);

ExecutionInput executionInput = ExecutionInput.newExecutionInput()
        .graphQLContext(contextMap)
        .query(queryString)
        .build();
graphql.executeAsync(executionInput);
```