### PR TITLE
update CI workflows to only use pull_request event

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,14 +1,13 @@
 name: Pull Request Federation Compatibility Check
 
 on:
-  pull_request_target:
-    branches:
-      - master
-    paths-ignore:
-      - '*.md'
+  workflow_call:
+    secrets:
+      token:
+        required: false
 
 jobs:
-  integration:
+  compatibility:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     defaults:
@@ -18,8 +17,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -41,8 +38,7 @@ jobs:
         with:
           compose: 'docker-compose.yaml'
           schema: 'src/main/resources/graphql/schema.graphqls'
-          debug: true
-          token: ${{ secrets.PAT }}
           failOnWarning: true
           failOnRequired: true
           workingDirectory: 'compatibility'
+          token: ${{ secrets.token }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,43 +13,14 @@ jobs:
 
   integration:
     needs: build
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: compatibility
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up Java 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'temurin'
-
-      - name: Set up Gradle cache
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build app with Gradle
-        run: ./gradlew bootJar
-
-      - name: Compatibility Test
-        uses: apollographql/federation-subgraph-compatibility@v1
-        with:
-          compose: 'docker-compose.yaml'
-          schema: 'src/main/resources/graphql/schema.graphqls'
-          failOnWarning: true
-          failOnRequired: true
-          workingDirectory: 'compatibility'
+    uses: ./.github/workflows/compatibility.yml
 
   release-notes:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Release Drafter
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,3 +10,11 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+
+  integration:
+    needs: build
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/compatibility.yml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updating federation compatibility check to trigger on `pull_request` and use regular `GITHUB_TOKEN`. This eliminates potential security vulnerability on workflows triggered through `pull_request_target` event but has a drawback that comments from compatibility action will only work on PRs from origin (i.e. it will no longer be able to comment on PRs from forks).