### PR TITLE
breaking: update to graphql-java v21 and Java 11 baseline

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,5 +9,5 @@ repositories {
 }
 
 dependencies {
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.17.0")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.20.0")
 }

--- a/buildSrc/src/main/kotlin/com.apollographql.federation.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.apollographql.federation.java-conventions.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 
     if (!version.toString().endsWith("SNAPSHOT")) {
         withJavadocJar()
@@ -83,8 +83,7 @@ spotless {
     java {
         importOrder()
         removeUnusedImports()
-        // Note that later versions use a bytecode target incompatible with Java SE 8
-        googleJavaFormat("1.7")
+        googleJavaFormat("1.17.0")
         // exclude generated proto
         targetExclude("build/generated/**/*.java")
     }

--- a/compatibility/build.gradle.kts
+++ b/compatibility/build.gradle.kts
@@ -1,8 +1,8 @@
 import java.util.Properties
 
 plugins {
-    id("org.springframework.boot") version "3.0.6"
-    id("io.spring.dependency-management") version "1.1.0"
+    id("org.springframework.boot") version "3.1.1"
+    id("io.spring.dependency-management") version "1.1.2"
     java
 }
 

--- a/compatibility/gradle.properties
+++ b/compatibility/gradle.properties
@@ -1,1 +1,1 @@
-graphql-java.version = 20.2
+graphql-java.version = 21.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ version = 2.0-SNAPSHOT
 
 # dependencies
 annotationsVersion = 24.0.1
-graphQLJavaVersion = 20.2
-protobufVersion = 3.22.3
+graphQLJavaVersion = 21.0
+protobufVersion = 3.23.4
 slf4jVersion = 1.7.36
 
 # test dependencies
-junitVersion = 5.9.2
+junitVersion = 5.9.3
 
 # plugin versions
 nexusPublishPluginVersion = 1.1.0

--- a/graphql-java-support/build.gradle.kts
+++ b/graphql-java-support/build.gradle.kts
@@ -2,7 +2,7 @@ description = "GraphQL Java server support for Apollo Federation"
 
 plugins {
     id("com.apollographql.federation.java-conventions")
-    id("com.google.protobuf") version "0.9.2"
+    id("com.google.protobuf") version "0.9.4"
 }
 
 val annotationsVersion: String by project
@@ -20,6 +20,6 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.22.3"
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
     }
 }


### PR DESCRIPTION
This is a breaking change as `graphql-java` v21 requires Java 11.