### PR TITLE
fix: include full `@link` directive definition

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -3,6 +3,7 @@ package com.apollographql.federation.graphqljava;
 import static com.apollographql.federation.graphqljava.directives.LinkDirectiveProcessor.loadFederationImportedDefinitions;
 
 import graphql.language.DirectiveDefinition;
+import graphql.language.EnumTypeDefinition;
 import graphql.language.FieldDefinition;
 import graphql.language.ObjectTypeDefinition;
 import graphql.language.SDLNamedDefinition;
@@ -160,9 +161,8 @@ public final class Federation {
           if (def instanceof DirectiveDefinition
               && !typeRegistry.getDirectiveDefinition(def.getName()).isPresent()) {
             typeRegistry.add(def);
-          }
-          if (def instanceof ScalarTypeDefinition
-              && !runtimeWiring.getScalars().containsKey(def.getName())) {
+          } else if (def instanceof ScalarTypeDefinition
+              && !typeRegistry.scalars().containsKey(def.getName())) {
             typeRegistry.add(def);
             scalarTypesToAdd.add(
                 GraphQLScalarType.newScalar()
@@ -170,6 +170,9 @@ public final class Federation {
                     .description(null)
                     .coercing(_Any.type.getCoercing())
                     .build());
+          } else if (def instanceof EnumTypeDefinition
+              && !typeRegistry.types().containsKey(def.getName())) {
+            typeRegistry.add(def);
           }
         });
 

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkImportsRenamingVisitor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkImportsRenamingVisitor.java
@@ -4,6 +4,7 @@ import static graphql.util.TreeTransformerUtil.changeNode;
 
 import com.apollographql.federation.graphqljava.exceptions.UnsupportedRenameException;
 import graphql.language.DirectiveDefinition;
+import graphql.language.EnumTypeDefinition;
 import graphql.language.NamedNode;
 import graphql.language.Node;
 import graphql.language.NodeVisitorStub;
@@ -43,6 +44,9 @@ class LinkImportsRenamingVisitor extends NodeVisitorStub {
       } else if (node instanceof DirectiveDefinition) {
         String newName = newName(((NamedNode<?>) node).getName(), fed2Imports, true);
         newNode = ((DirectiveDefinition) node).transform(builder -> builder.name(newName));
+      } else if (node instanceof EnumTypeDefinition) {
+        String newName = newName(((NamedNode<?>) node).getName(), fed2Imports, true);
+        newNode = ((EnumTypeDefinition) node).transform(builder -> builder.name(newName));
       }
       if (newNode != null) {
         return changeNode(context, newNode);
@@ -78,7 +82,7 @@ class LinkImportsRenamingVisitor extends NodeVisitorStub {
     } else {
       if (name.equals("inaccessible") || name.equals("tag")) {
         return name;
-      } else if (name.equals("Import")) {
+      } else if (name.equals("Import") || name.equals("Purpose")) {
         return "link__" + name;
       } else {
         // apply default namespace

--- a/graphql-java-support/src/main/resources/definitions_fed2_0.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_0.graphqls
@@ -40,7 +40,13 @@ scalar FieldSet
 directive @link(
     url: String!,
     as: String,
-    import: [Import])
+    import: [Import],
+    for: Purpose)
 repeatable on SCHEMA
 
 scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}

--- a/graphql-java-support/src/main/resources/definitions_fed2_1.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_1.graphqls
@@ -34,19 +34,25 @@ directive @tag(name: String!) repeatable on
 scalar FieldSet
 
 #
-# federation-v2.1
-#
-
-directive @composeDirective(name: String!) repeatable on SCHEMA
-
-#
 # https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
 #
 
 directive @link(
     url: String!,
     as: String,
-    import: [Import])
+    import: [Import],
+    for: Purpose)
 repeatable on SCHEMA
 
 scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA

--- a/graphql-java-support/src/main/resources/definitions_fed2_2.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_2.graphqls
@@ -33,22 +33,28 @@ directive @tag(name: String!) repeatable on
 scalar FieldSet
 
 #
-# federation-v2.1
-#
-
-directive @composeDirective(name: String!) repeatable on SCHEMA
-
-#
 # https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
 #
 
 directive @link(
     url: String!,
     as: String,
-    import: [Import])
+    import: [Import],
+    for: Purpose)
 repeatable on SCHEMA
 
 scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
 
 #
 # federation-v2.2

--- a/graphql-java-support/src/main/resources/definitions_fed2_3.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_3.graphqls
@@ -33,22 +33,28 @@ directive @tag(name: String!) repeatable on
 scalar FieldSet
 
 #
-# federation-v2.1
-#
-
-directive @composeDirective(name: String!) repeatable on SCHEMA
-
-#
 # https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
 #
 
 directive @link(
     url: String!,
     as: String,
-    import: [Import])
+    import: [Import],
+    for: Purpose)
 repeatable on SCHEMA
 
 scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
 
 #
 # federation-v2.2

--- a/graphql-java-support/src/main/resources/definitions_fed2_5.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_5.graphqls
@@ -39,10 +39,16 @@ scalar FieldSet
 directive @link(
     url: String!,
     as: String,
-    import: [Import])
+    import: [Import],
+    for: Purpose)
 repeatable on SCHEMA
 
 scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}
 
 #
 # federation-v2.1

--- a/graphql-java-support/src/test/resources/schemas/authorization_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/authorization_federated.graphql
@@ -24,7 +24,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @requiresScopes(scopes: [[Scope!]!]!) on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 
@@ -46,6 +46,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar FieldSet

--- a/graphql-java-support/src/test/resources/schemas/composeDirective_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/composeDirective_federated.graphql
@@ -22,7 +22,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @myDirective(foo: String!) on FIELD_DEFINITION
 
@@ -44,6 +44,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/customAuthenticated_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/customAuthenticated_federated.graphql
@@ -28,7 +28,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -48,6 +48,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/extendSchema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/extendSchema_federated.graphql
@@ -18,7 +18,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -36,6 +36,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/federationV2_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/federationV2_federated.graphql
@@ -16,7 +16,7 @@ directive @interfaceObject on OBJECT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @override(from: String!) on FIELD_DEFINITION
 
@@ -90,6 +90,11 @@ type User @key(fields : "email", resolvable : true) {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/interfaceEntity_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceEntity_federated.graphql
@@ -22,7 +22,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -56,6 +56,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/interfaceObject_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObject_federated.graphql
@@ -22,7 +22,7 @@ directive @interfaceObject on OBJECT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -41,6 +41,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/nonResolvableKey_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/nonResolvableKey_federated.graphql
@@ -22,7 +22,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -46,6 +46,11 @@ type User @key(fields : "email", resolvable : false) {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/renamedImports_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/renamedImports_federated.graphql
@@ -10,7 +10,7 @@ directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITI
 
 directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @myKey(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
@@ -55,6 +55,11 @@ type User @myKey(fields : "email", resolvable : true) {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar federation__FieldSet

--- a/graphql-java-support/src/test/resources/schemas/repeatableShareable_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/repeatableShareable_federated.graphql
@@ -18,7 +18,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
@@ -46,6 +46,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any

--- a/graphql-java-support/src/test/resources/schemas/schemaImport_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/schemaImport_federated.graphql
@@ -18,7 +18,7 @@ directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINIT
 
 directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 
-directive @link(as: String, import: [link__Import], url: String!) repeatable on SCHEMA
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
 directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -37,6 +37,11 @@ type Query {
 
 type _Service {
   sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
 }
 
 scalar _Any


### PR DESCRIPTION
Add missing `Purpose` enum. Full `@link` definition as per the [spec](https://github.com/apollographql/specs/blob/main/link/v1.0/link-v1.0.graphql):

```graphql
directive @link(
    url: String!,
    as: String,
    import: [Import],
    for: Purpose)
repeatable on SCHEMA

scalar Import

enum Purpose {
  SECURITY
  EXECUTION
}
```

Resolves: #351 