### PR TITLE
fix: `@authenticated` and `@requiresScopes` only apply to fed v2.5

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
@@ -77,6 +77,14 @@ public final class LinkDirectiveProcessor {
       throw new UnsupportedLinkImportException("@interfaceObject");
     }
 
+    if (imports.containsKey("@authenticated") && !isAuthorizationSupported(federationVersion)) {
+      throw new UnsupportedLinkImportException("@authenticated");
+    }
+
+    if (imports.containsKey("@requiresScopes") && !isAuthorizationSupported(federationVersion)) {
+      throw new UnsupportedLinkImportException("@requiresScopes");
+    }
+
     return loadFederationSpecDefinitions(specLink).stream()
         .map(
             definition ->
@@ -100,6 +108,10 @@ public final class LinkDirectiveProcessor {
 
   private static boolean isInterfaceObjectSupported(int federationVersion) {
     return federationVersion >= 23;
+  }
+
+  private static boolean isAuthorizationSupported(int federationVersion) {
+    return federationVersion >= 25;
   }
 
   private static Stream<Directive> getFederationLinkDirectives(SchemaDefinition schemaDefinition) {

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -309,6 +309,25 @@ class FederationTest {
     verifyFederationTransformation("schemas/customAuthenticated.graphql", true);
   }
 
+  @Test
+  public void verifyFederationV2Transformation_authorizedFromUnsupportedVersion_throwsException() {
+    final String schemaSDL =
+        FileUtils.readResource("schemas/authenticatedUnsupportedSpecVersion.graphql");
+    assertThrows(
+        UnsupportedLinkImportException.class,
+        () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
+  }
+
+  @Test
+  public void
+      verifyFederationV2Transformation_requiresScopesFromUnsupportedVersion_throwsException() {
+    final String schemaSDL =
+        FileUtils.readResource("schemas/requiresScopesUnsupportedSpecVersion.graphql");
+    assertThrows(
+        UnsupportedLinkImportException.class,
+        () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
+  }
+
   private GraphQLSchema verifyFederationTransformation(
       String schemaFileName, boolean isFederationV2) {
     final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();

--- a/graphql-java-support/src/test/resources/schemas/authenticatedUnsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/authenticatedUnsupportedSpecVersion.graphql
@@ -1,0 +1,11 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@authenticated", "@key", "FieldSet"])
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String!
+    supplier: String
+}
+
+type Query {
+    product(id: ID!): Product @authenticated
+}

--- a/graphql-java-support/src/test/resources/schemas/requiresScopesUnsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/requiresScopesUnsupportedSpecVersion.graphql
@@ -1,0 +1,11 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@requiresScopes", "Scope", "FieldSet"])
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String!
+    supplier: String @requiresScopes(scopes: [["scopeA"]])
+}
+
+type Query {
+    product(id: ID!): Product
+}


### PR DESCRIPTION
Attempting to import new directives with old specification version will throw exception.