### PR TITLE
Default to not tracing

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -499,7 +499,7 @@ public class FederatedTracingInstrumentation extends SimplePerformantInstrumenta
         return FEDERATED_TRACING_HEADER_VALUE.equals(
             executionInput.getGraphQLContext().get(FEDERATED_TRACING_HEADER_NAME));
       }
-      return true;
+      return false;
     }
   }
 }


### PR DESCRIPTION
Federation tracing should only be enabled if the Router/Gateway sends the proper ftv1 header and value. We want to default to false so we are not wasting CPU cycles tracking resolvers and building the extensions if it not going to be used

https://www.apollographql.com/docs/federation/metrics/

We need tests. Just making this to start discussion