### PR TITLE
chore: update to graphql-java 21.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version = 3.0-SNAPSHOT
 
 # dependencies
 annotationsVersion = 24.1.0
-graphQLJavaVersion = 21.1
+graphQLJavaVersion = 21.3
 mockWebServerVersion = 4.12.0
 protobufVersion = 3.25.2
 slf4jVersion = 2.0.11

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/printer/ServiceSDLPrinter.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/printer/ServiceSDLPrinter.java
@@ -30,7 +30,7 @@ public final class ServiceSDLPrinter {
 
   // Apollo Gateway will fail Federation v1 composition if it sees standard directive definitions.
   private static final Set<String> STANDARD_DIRECTIVES =
-      new HashSet<>(Arrays.asList("deprecated", "include", "skip", "specifiedBy"));
+      new HashSet<>(Arrays.asList("deprecated", "include", "oneOf", "skip", "specifiedBy"));
 
   private ServiceSDLPrinter() {
     // hidden constructor as this is static utility class
@@ -130,13 +130,11 @@ public final class ServiceSDLPrinter {
    */
   public static String generateServiceSDLV2(GraphQLSchema schema) {
     // federation v2 SDL does not need to filter federation directive definitions
-    final Set<String> standardDirectives =
-        new HashSet<>(Arrays.asList("deprecated", "include", "skip", "specifiedBy"));
     return new SchemaPrinter(
             SchemaPrinter.Options.defaultOptions()
                 .includeSchemaDefinition(true)
                 .includeScalarTypes(true)
-                .includeDirectives(def -> !standardDirectives.contains(def)))
+                .includeDirectives(def -> !STANDARD_DIRECTIVES.contains(def)))
         .print(schema)
         .trim();
   }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederatedSchemaVerifier.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederatedSchemaVerifier.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Assertions;
 
 final class FederatedSchemaVerifier {
   public static final Set<String> standardDirectives =
-      new HashSet<>(Arrays.asList("deprecated", "include", "skip", "specifiedBy"));
+      new HashSet<>(Arrays.asList("deprecated", "include", "oneOf", "skip", "specifiedBy"));
 
   private FederatedSchemaVerifier() {}
 


### PR DESCRIPTION
`graphql-java` added support for `@oneOf` built-in directive.

Supersedes: https://github.com/apollographql/federation-jvm/pull/358