### PR TITLE
fix: default to not generate ftv1 traces

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentation.java
@@ -499,7 +499,7 @@ public class FederatedTracingInstrumentation extends SimplePerformantInstrumenta
         return FEDERATED_TRACING_HEADER_VALUE.equals(
             executionInput.getGraphQLContext().get(FEDERATED_TRACING_HEADER_NAME));
       }
-      return true;
+      return false;
     }
   }
 }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentationTest.java
@@ -85,7 +85,9 @@ class FederatedTracingInstrumentationTest {
   void testTracing() throws InvalidProtocolBufferException {
     Map<String, Object> result =
         graphql
-            .execute(createExecutionInput("{ widgets { foo, baz: bar }, listOfLists { foo }, listOfScalars }"))
+            .execute(
+                createExecutionInput(
+                    "{ widgets { foo, baz: bar }, listOfLists { foo }, listOfScalars }"))
             .toSpecification();
 
     Object extensions = result.get("extensions");
@@ -173,7 +175,8 @@ class FederatedTracingInstrumentationTest {
 
   @Test
   void testTracingParseErrors() throws InvalidProtocolBufferException {
-    Map<String, Object> result = graphql.execute(createExecutionInput("{ widgets { foo }")).toSpecification();
+    Map<String, Object> result =
+        graphql.execute(createExecutionInput("{ widgets { foo }")).toSpecification();
 
     Object extensions = result.get("extensions");
     assertTrue(extensions instanceof Map);
@@ -192,7 +195,8 @@ class FederatedTracingInstrumentationTest {
 
   @Test
   void testTracingValidationErrors() throws InvalidProtocolBufferException {
-    Map<String, Object> result = graphql.execute(createExecutionInput("{ widgets { notARealThing } }")).toSpecification();
+    Map<String, Object> result =
+        graphql.execute(createExecutionInput("{ widgets { notARealThing } }")).toSpecification();
 
     Object extensions = result.get("extensions");
     assertTrue(extensions instanceof Map);
@@ -265,7 +269,8 @@ class FederatedTracingInstrumentationTest {
 
     Map<String, Object> result = graphql.execute(input).toSpecification();
     Object extensions = result.get("extensions");
-    // Because the special header isn't there, we fallback to the default behavior of not generating ftv1
+    // Because the special header isn't there, we fallback to the default behavior of not generating
+    // ftv1
     assertNull(extensions);
 
     // Try again with the header having the wrong value.
@@ -287,7 +292,7 @@ class FederatedTracingInstrumentationTest {
 
   private static ExecutionInput createExecutionInput(String query) {
     return ExecutionInput.newExecutionInput(query)
-      .graphQLContext(Map.of(FEDERATED_TRACING_HEADER_NAME, FEDERATED_TRACING_HEADER_VALUE))
-      .build();
+        .graphQLContext(Map.of(FEDERATED_TRACING_HEADER_NAME, FEDERATED_TRACING_HEADER_VALUE))
+        .build();
   }
 }

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/tracing/FederatedTracingInstrumentationTest.java
@@ -85,7 +85,7 @@ class FederatedTracingInstrumentationTest {
   void testTracing() throws InvalidProtocolBufferException {
     Map<String, Object> result =
         graphql
-            .execute("{ widgets { foo, baz: bar }, listOfLists { foo }, listOfScalars }")
+            .execute(createExecutionInput("{ widgets { foo, baz: bar }, listOfLists { foo }, listOfScalars }"))
             .toSpecification();
 
     Object extensions = result.get("extensions");
@@ -173,7 +173,7 @@ class FederatedTracingInstrumentationTest {
 
   @Test
   void testTracingParseErrors() throws InvalidProtocolBufferException {
-    Map<String, Object> result = graphql.execute("{ widgets { foo }").toSpecification();
+    Map<String, Object> result = graphql.execute(createExecutionInput("{ widgets { foo }")).toSpecification();
 
     Object extensions = result.get("extensions");
     assertTrue(extensions instanceof Map);
@@ -192,7 +192,7 @@ class FederatedTracingInstrumentationTest {
 
   @Test
   void testTracingValidationErrors() throws InvalidProtocolBufferException {
-    Map<String, Object> result = graphql.execute("{ widgets { notARealThing } }").toSpecification();
+    Map<String, Object> result = graphql.execute(createExecutionInput("{ widgets { notARealThing } }")).toSpecification();
 
     Object extensions = result.get("extensions");
     assertTrue(extensions instanceof Map);
@@ -263,11 +263,10 @@ class FederatedTracingInstrumentationTest {
   void testTracingWithGraphQLContextMap() {
     ExecutionInput input = ExecutionInput.newExecutionInput("{widgets {foo}}").build();
 
-    // Because the special header isn't there, we fallback to the default behavior
     Map<String, Object> result = graphql.execute(input).toSpecification();
     Object extensions = result.get("extensions");
-    assertTrue(extensions instanceof Map);
-    assertTrue(((Map) extensions).containsKey("ftv1"));
+    // Because the special header isn't there, we fallback to the default behavior of not generating ftv1
+    assertNull(extensions);
 
     // Try again with the header having the wrong value.
     Map<String, Object> context = new HashMap<>();
@@ -284,5 +283,11 @@ class FederatedTracingInstrumentationTest {
     extensions = result.get("extensions");
     assertTrue(extensions instanceof Map);
     assertTrue(((Map) extensions).containsKey("ftv1"));
+  }
+
+  private static ExecutionInput createExecutionInput(String query) {
+    return ExecutionInput.newExecutionInput(query)
+      .graphQLContext(Map.of(FEDERATED_TRACING_HEADER_NAME, FEDERATED_TRACING_HEADER_VALUE))
+      .build();
   }
 }


### PR DESCRIPTION
Federation tracing should only be enabled if the Router/Gateway sends the proper `ftv1` header and value. Currently trace data is generated even if the header is not specified which leads to unnecessary computations of data that will ultimately be discarded by the Router/Gateway.... If header is not specified, we should default to `false` to avoid those unnecessary computations.

See: https://www.apollographql.com/docs/federation/metrics/

Supersedes: https://github.com/apollographql/federation-jvm/pull/368