### PR TITLE
feat: add support for fed v2.6 and v2.7

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -32,6 +32,8 @@ public final class Federation {
   public static final String FEDERATION_SPEC_V2_3 = "https://specs.apollo.dev/federation/v2.3";
   public static final String FEDERATION_SPEC_V2_4 = "https://specs.apollo.dev/federation/v2.4";
   public static final String FEDERATION_SPEC_V2_5 = "https://specs.apollo.dev/federation/v2.5";
+  public static final String FEDERATION_SPEC_V2_6 = "https://specs.apollo.dev/federation/v2.6";
+  public static final String FEDERATION_SPEC_V2_7 = "https://specs.apollo.dev/federation/v2.7";
 
   private static final SchemaGenerator.Options generatorOptions =
       SchemaGenerator.Options.defaultOptions();

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -6,6 +6,8 @@ import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPE
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_3;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_4;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_5;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_6;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_7;
 import static graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION;
 import static graphql.introspection.Introspection.DirectiveLocation.INTERFACE;
 import static graphql.introspection.Introspection.DirectiveLocation.OBJECT;
@@ -223,6 +225,10 @@ public final class FederationDirectives {
         return loadFed2Definitions("definitions_fed2_3.graphqls");
       case FEDERATION_SPEC_V2_5:
         return loadFed2Definitions("definitions_fed2_5.graphqls");
+      case FEDERATION_SPEC_V2_6:
+        return loadFed2Definitions("definitions_fed2_6.graphqls");
+      case FEDERATION_SPEC_V2_7:
+        return loadFed2Definitions("definitions_fed2_7.graphqls");
       default:
         throw new UnsupportedFederationVersionException(federationSpec);
     }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/directives/LinkDirectiveProcessor.java
@@ -26,6 +26,14 @@ import org.jetbrains.annotations.Nullable;
 
 public final class LinkDirectiveProcessor {
 
+  private static final Map<String, Integer> DIRECTIVES_BY_MIN_SUPPORTED_VERSION =
+      Map.of(
+          "@composeDirective", 21,
+          "@interfaceObject", 23,
+          "@authenticated", 25,
+          "@requiresScopes", 25,
+          "@policy", 26);
+
   private LinkDirectiveProcessor() {}
 
   /**
@@ -68,21 +76,9 @@ public final class LinkDirectiveProcessor {
     final String specLink = ((StringValue) urlArgument.getValue()).getValue();
 
     final int federationVersion = parseFederationVersion(specLink);
-    if (imports.containsKey("@composeDirective")
-        && !isComposeDirectiveSupported(federationVersion)) {
-      throw new UnsupportedLinkImportException("@composeDirective");
-    }
-
-    if (imports.containsKey("@interfaceObject") && !isInterfaceObjectSupported(federationVersion)) {
-      throw new UnsupportedLinkImportException("@interfaceObject");
-    }
-
-    if (imports.containsKey("@authenticated") && !isAuthorizationSupported(federationVersion)) {
-      throw new UnsupportedLinkImportException("@authenticated");
-    }
-
-    if (imports.containsKey("@requiresScopes") && !isAuthorizationSupported(federationVersion)) {
-      throw new UnsupportedLinkImportException("@requiresScopes");
+    for (Map.Entry<String, Integer> directiveInfo : DIRECTIVES_BY_MIN_SUPPORTED_VERSION.entrySet()) {
+      validateDirectiveSupport(
+          imports, federationVersion, directiveInfo.getKey(), directiveInfo.getValue());
     }
 
     return loadFederationSpecDefinitions(specLink).stream()
@@ -102,16 +98,11 @@ public final class LinkDirectiveProcessor {
     }
   }
 
-  private static boolean isComposeDirectiveSupported(int federationVersion) {
-    return federationVersion >= 21;
-  }
-
-  private static boolean isInterfaceObjectSupported(int federationVersion) {
-    return federationVersion >= 23;
-  }
-
-  private static boolean isAuthorizationSupported(int federationVersion) {
-    return federationVersion >= 25;
+  private static void validateDirectiveSupport(
+      Map<String, String> imports, int version, String directiveName, int minVersion) {
+    if (imports.containsKey(directiveName) && version < minVersion) {
+      throw new UnsupportedLinkImportException(directiveName, minVersion, version);
+    }
   }
 
   private static Stream<Directive> getFederationLinkDirectives(SchemaDefinition schemaDefinition) {

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedLinkImportException.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/exceptions/UnsupportedLinkImportException.java
@@ -17,8 +17,10 @@ public class UnsupportedLinkImportException extends RuntimeException {
     super("Unsupported import: " + importedDefinition);
   }
 
-  public UnsupportedLinkImportException(String importedDefinition) {
+  public UnsupportedLinkImportException(String importedDefinition, int minVersion, int version) {
     super(
-        "New Federation feature " + importedDefinition + " imported using old Federation version");
+        String.format(
+            "Federation v%.1f feature %s imported using old Federation v%.1f version",
+            minVersion / 10.0, importedDefinition, version / 10.0));
   }
 }

--- a/graphql-java-support/src/main/resources/definitions_fed2_6.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_6.graphqls
@@ -1,0 +1,102 @@
+#
+# https://specs.apollo.dev/federation/v2.0/federation-v2.0.graphql
+#
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
+directive @extends on OBJECT | INTERFACE
+directive @override(from: String!) on FIELD_DEFINITION
+directive @inaccessible on
+    | FIELD_DEFINITION
+    | OBJECT
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | SCALAR
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+scalar FieldSet
+
+#
+# https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
+#
+
+directive @link(
+    url: String!,
+    as: String,
+    import: [Import],
+    for: Purpose)
+repeatable on SCHEMA
+
+scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+#
+# federation-v2.2
+#
+
+directive @shareable repeatable on FIELD_DEFINITION | OBJECT
+
+#
+# federation-v2.3
+#
+
+directive @interfaceObject on OBJECT
+
+#
+# federation-v2.5
+#
+
+directive @authenticated on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+
+directive @requiresScopes(scopes: [[Scope!]!]!) on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+
+scalar Scope
+
+#
+# federation-v2.6
+#
+
+directive @policy(policies: [[Policy!]!]!) on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+
+scalar Policy

--- a/graphql-java-support/src/main/resources/definitions_fed2_7.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_7.graphqls
@@ -1,0 +1,107 @@
+#
+# https://specs.apollo.dev/federation/v2.0/federation-v2.0.graphql
+#
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @external on OBJECT | FIELD_DEFINITION
+directive @extends on OBJECT | INTERFACE
+directive @inaccessible on
+    | FIELD_DEFINITION
+    | OBJECT
+    | INTERFACE
+    | UNION
+    | ENUM
+    | ENUM_VALUE
+    | SCALAR
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+scalar FieldSet
+
+#
+# https://specs.apollo.dev/link/v1.0/link-v1.0.graphql
+#
+
+directive @link(
+    url: String!,
+    as: String,
+    import: [Import],
+    for: Purpose)
+repeatable on SCHEMA
+
+scalar Import
+
+enum Purpose {
+  SECURITY
+  EXECUTION
+}
+
+#
+# federation-v2.1
+#
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+#
+# federation-v2.2
+#
+
+directive @shareable repeatable on FIELD_DEFINITION | OBJECT
+
+#
+# federation-v2.3
+#
+
+directive @interfaceObject on OBJECT
+
+#
+# federation-v2.5
+#
+
+directive @authenticated on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+
+directive @requiresScopes(scopes: [[Scope!]!]!) on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+
+scalar Scope
+
+#
+# federation-v2.6
+#
+
+directive @policy(policies: [[Policy!]!]!) on
+    ENUM
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | SCALAR
+
+scalar Policy
+
+#
+# federation-v2.7
+#
+
+directive @override(from: String!, label: String) on FIELD_DEFINITION

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -335,12 +335,12 @@ class FederationTest {
 
   @Test
   public void
-  verifyFederationV2Transformation_progressiveOverrideFromUnsupportedVersion_throwsException() {
+      verifyFederationV2Transformation_progressiveOverrideFromUnsupportedVersion_throwsException() {
     final String schemaSDL =
-      FileUtils.readResource("schemas/progressiveOverrideUnsupportedSpecVersion.graphql");
+        FileUtils.readResource("schemas/progressiveOverrideUnsupportedSpecVersion.graphql");
     assertThrows(
-      SchemaProblem.class,
-      () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
+        SchemaProblem.class,
+        () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
   }
 
   private GraphQLSchema verifyFederationTransformation(

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -328,6 +328,11 @@ class FederationTest {
         () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
   }
 
+  @Test
+  public void verifyFederationV2Transformation_progressiveOverride() {
+    verifyFederationTransformation("schemas/progressiveOverride.graphql", true);
+  }
+
   private GraphQLSchema verifyFederationTransformation(
       String schemaFileName, boolean isFederationV2) {
     final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -333,6 +333,16 @@ class FederationTest {
     verifyFederationTransformation("schemas/progressiveOverride.graphql", true);
   }
 
+  @Test
+  public void
+  verifyFederationV2Transformation_progressiveOverrideFromUnsupportedVersion_throwsException() {
+    final String schemaSDL =
+      FileUtils.readResource("schemas/progressiveOverrideUnsupportedSpecVersion.graphql");
+    assertThrows(
+      SchemaProblem.class,
+      () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
+  }
+
   private GraphQLSchema verifyFederationTransformation(
       String schemaFileName, boolean isFederationV2) {
     final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -319,10 +319,23 @@ class FederationTest {
   }
 
   @Test
+  public void verifyFederationV2Transformation_policy() {
+    verifyFederationTransformation("schemas/policy.graphql", true);
+  }
+
+  @Test
   public void
       verifyFederationV2Transformation_requiresScopesFromUnsupportedVersion_throwsException() {
     final String schemaSDL =
         FileUtils.readResource("schemas/requiresScopesUnsupportedSpecVersion.graphql");
+    assertThrows(
+        UnsupportedLinkImportException.class,
+        () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());
+  }
+
+  @Test
+  public void verifyFederationV2Transformation_policyFromUnsupportedVersion_throwsException() {
+    final String schemaSDL = FileUtils.readResource("schemas/policyUnsupportedSpecVersion.graphql");
     assertThrows(
         UnsupportedLinkImportException.class,
         () -> Federation.transform(schemaSDL).fetchEntities(env -> null).build());

--- a/graphql-java-support/src/test/resources/schemas/policy.graphql
+++ b/graphql-java-support/src/test/resources/schemas/policy.graphql
@@ -1,0 +1,11 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@policy", "Policy", "FieldSet"])
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String!
+    supplier: String @policy(policies: [["policyA"]])
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/policyUnsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/policyUnsupportedSpecVersion.graphql
@@ -1,0 +1,11 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@policy", "Policy", "FieldSet"])
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String!
+    supplier: String @policy(policies: [["policy"]])
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/policy_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/policy_federated.graphql
@@ -1,0 +1,66 @@
+schema @link(import : ["@key", "@policy", "Policy", "FieldSet"], url : "https://specs.apollo.dev/federation/v2.6"){
+  query: Query
+}
+
+directive @federation__authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
+
+directive @federation__composeDirective(name: String!) repeatable on SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__external on OBJECT | FIELD_DEFINITION
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__override(from: String!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: FieldSet!) on FIELD_DEFINITION
+
+directive @federation__requires(fields: FieldSet!) on FIELD_DEFINITION
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
+
+directive @federation__shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
+
+directive @policy(policies: [[Policy!]!]!) on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
+
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+union _Entity = Product
+
+type Product @key(fields : "id", resolvable : true) {
+  id: ID!
+  name: String!
+  supplier: String @policy(policies : [["policyA"]])
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  product(id: ID!): Product
+}
+
+type _Service {
+  sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
+}
+
+scalar FieldSet
+
+scalar Policy
+
+scalar _Any
+
+scalar federation__Scope
+
+scalar link__Import

--- a/graphql-java-support/src/test/resources/schemas/progressiveOverride.graphql
+++ b/graphql-java-support/src/test/resources/schemas/progressiveOverride.graphql
@@ -1,0 +1,29 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.7", import: [
+  "@authenticated",
+  "@composeDirective",
+  "@extends",
+  "@external",
+  "@inaccessible",
+  "@interfaceObject",
+  "@key",
+  "@override",
+  "@policy",
+  "@provides",
+  "@requires",
+  "@requiresScopes",
+  "@shareable",
+  "@tag",
+  "FieldSet",
+  "Import",
+  "Policy",
+  "Scope"
+])
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String! @override(from: "old-product-service", label: "percent(5)")
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/progressiveOverrideUnsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/progressiveOverrideUnsupportedSpecVersion.graphql
@@ -1,0 +1,29 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: [
+  "@authenticated",
+  "@composeDirective",
+  "@extends",
+  "@external",
+  "@inaccessible",
+  "@interfaceObject",
+  "@key",
+  "@override",
+  "@policy",
+  "@provides",
+  "@requires",
+  "@requiresScopes",
+  "@shareable",
+  "@tag",
+  "FieldSet",
+  "Import",
+  "Policy",
+  "Scope"
+])
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String! @override(from: "old-product-service", label: "percent(5)")
+}
+
+type Query {
+    product(id: ID!): Product
+}

--- a/graphql-java-support/src/test/resources/schemas/progressiveOverrideUnsupportedSpecVersion.graphql
+++ b/graphql-java-support/src/test/resources/schemas/progressiveOverrideUnsupportedSpecVersion.graphql
@@ -1,22 +1,6 @@
 extend schema @link(url: "https://specs.apollo.dev/federation/v2.6", import: [
-  "@authenticated",
-  "@composeDirective",
-  "@extends",
-  "@external",
-  "@inaccessible",
-  "@interfaceObject",
   "@key",
-  "@override",
-  "@policy",
-  "@provides",
-  "@requires",
-  "@requiresScopes",
-  "@shareable",
-  "@tag",
-  "FieldSet",
-  "Import",
-  "Policy",
-  "Scope"
+  "@override"
 ])
 
 type Product @key(fields: "id") {

--- a/graphql-java-support/src/test/resources/schemas/progressiveOverride_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/progressiveOverride_federated.graphql
@@ -1,0 +1,65 @@
+schema @link(import : ["@authenticated", "@composeDirective", "@extends", "@external", "@inaccessible", "@interfaceObject", "@key", "@override", "@policy", "@provides", "@requires", "@requiresScopes", "@shareable", "@tag", "FieldSet", "Import", "Policy", "Scope"], url : "https://specs.apollo.dev/federation/v2.7"){
+  query: Query
+}
+
+directive @authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+directive @extends on OBJECT | INTERFACE
+
+directive @external on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @interfaceObject on OBJECT
+
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(as: String, for: link__Purpose, import: [Import], url: String!) repeatable on SCHEMA
+
+directive @override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @policy(policies: [[Policy!]!]!) on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
+
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+
+directive @requiresScopes(scopes: [[Scope!]!]!) on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
+
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+union _Entity = Product
+
+type Product @key(fields : "id", resolvable : true) {
+  id: ID!
+  name: String! @override(from : "old-product-service", label : "percent(5)")
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  product(id: ID!): Product
+}
+
+type _Service {
+  sdl: String!
+}
+
+enum link__Purpose {
+  EXECUTION
+  SECURITY
+}
+
+scalar FieldSet
+
+scalar Import
+
+scalar Policy
+
+scalar Scope
+
+scalar _Any


### PR DESCRIPTION
* federation v2.6 - new `@policy` directive, see [docs](https://www.apollographql.com/docs/federation/federated-types/federated-directives#policy) for details

```graphql
directive @policy(policies: [[federation__Policy!]!]!) on
  | FIELD_DEFINITION
  | OBJECT
  | INTERFACE
  | SCALAR
  | ENUM

scalar Policy
```

* federation v2.7 - update to `@override` definition (new `label` argument), see [docs](https://www.apollographql.com/docs/federation/federated-types/federated-directives#progressive-override) for details

```graphql
directive @override(from: String!, label: String) on FIELD_DEFINITION
```