### PR TITLE
fix: add missing SCHEMA `@tag` location

### DIFF
--- a/graphql-java-support/src/main/resources/definitions_fed2_3.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_3.graphqls
@@ -19,17 +19,6 @@ directive @inaccessible on
     | INPUT_OBJECT
     | INPUT_FIELD_DEFINITION
     | ARGUMENT_DEFINITION
-directive @tag(name: String!) repeatable on
-    | FIELD_DEFINITION
-    | INTERFACE
-    | OBJECT
-    | UNION
-    | ARGUMENT_DEFINITION
-    | SCALAR
-    | ENUM
-    | ENUM_VALUE
-    | INPUT_OBJECT
-    | INPUT_FIELD_DEFINITION
 scalar FieldSet
 
 #
@@ -67,3 +56,16 @@ directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 #
 
 directive @interfaceObject on OBJECT
+
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | SCHEMA

--- a/graphql-java-support/src/main/resources/definitions_fed2_5.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_5.graphqls
@@ -19,17 +19,6 @@ directive @inaccessible on
     | INPUT_OBJECT
     | INPUT_FIELD_DEFINITION
     | ARGUMENT_DEFINITION
-directive @tag(name: String!) repeatable on
-    | FIELD_DEFINITION
-    | INTERFACE
-    | OBJECT
-    | UNION
-    | ARGUMENT_DEFINITION
-    | SCALAR
-    | ENUM
-    | ENUM_VALUE
-    | INPUT_OBJECT
-    | INPUT_FIELD_DEFINITION
 scalar FieldSet
 
 #
@@ -67,6 +56,19 @@ directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 #
 
 directive @interfaceObject on OBJECT
+
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | SCHEMA
 
 #
 # federation-v2.5

--- a/graphql-java-support/src/main/resources/definitions_fed2_6.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_6.graphqls
@@ -68,6 +68,19 @@ directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 
 directive @interfaceObject on OBJECT
 
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | SCHEMA
+
 #
 # federation-v2.5
 #

--- a/graphql-java-support/src/main/resources/definitions_fed2_7.graphqls
+++ b/graphql-java-support/src/main/resources/definitions_fed2_7.graphqls
@@ -67,6 +67,19 @@ directive @shareable repeatable on FIELD_DEFINITION | OBJECT
 
 directive @interfaceObject on OBJECT
 
+directive @tag(name: String!) repeatable on
+    | FIELD_DEFINITION
+    | INTERFACE
+    | OBJECT
+    | UNION
+    | ARGUMENT_DEFINITION
+    | SCALAR
+    | ENUM
+    | ENUM_VALUE
+    | INPUT_OBJECT
+    | INPUT_FIELD_DEFINITION
+    | SCHEMA
+
 #
 # federation-v2.5
 #

--- a/graphql-java-support/src/test/resources/schemas/authorization/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/authorization/schema_federated.graphql
@@ -28,7 +28,7 @@ directive @link(as: String, for: link__Purpose, import: [link__Import], url: Str
 
 directive @requiresScopes(scopes: [[Scope!]!]!) on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Product
 

--- a/graphql-java-support/src/test/resources/schemas/authorization/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/authorization/schema_full.graphql
@@ -55,7 +55,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Product
 

--- a/graphql-java-support/src/test/resources/schemas/customAuthenticated/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/customAuthenticated/schema_federated.graphql
@@ -30,7 +30,7 @@ directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeat
 
 directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Product
 

--- a/graphql-java-support/src/test/resources/schemas/customAuthenticated/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/customAuthenticated/schema_full.graphql
@@ -57,7 +57,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Product
 

--- a/graphql-java-support/src/test/resources/schemas/fedV2/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/fedV2/schema_federated.graphql
@@ -26,7 +26,7 @@ directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
 directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = DeprecatedProduct | Inventory | Product | ProductResearch | User
 

--- a/graphql-java-support/src/test/resources/schemas/fedV2/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/fedV2/schema_full.graphql
@@ -53,7 +53,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = DeprecatedProduct | Inventory | Product | ProductResearch | User
 

--- a/graphql-java-support/src/test/resources/schemas/interfaceEntity/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceEntity/schema_federated.graphql
@@ -24,7 +24,7 @@ directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeat
 
 directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 interface Product @key(fields : "id", resolvable : true) {
   description: String

--- a/graphql-java-support/src/test/resources/schemas/interfaceEntity/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceEntity/schema_full.graphql
@@ -51,7 +51,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 interface Product @key(fields : "id", resolvable : true) {
   description: String

--- a/graphql-java-support/src/test/resources/schemas/interfaceObject/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObject/schema_federated.graphql
@@ -24,7 +24,7 @@ directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeat
 
 directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Product
 

--- a/graphql-java-support/src/test/resources/schemas/interfaceObject/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObject/schema_full.graphql
@@ -51,7 +51,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = Product
 

--- a/graphql-java-support/src/test/resources/schemas/nonResolvableKey/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/nonResolvableKey/schema_federated.graphql
@@ -24,7 +24,7 @@ directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeat
 
 directive @link(as: String, for: link__Purpose, import: [link__Import], url: String!) repeatable on SCHEMA
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = User
 

--- a/graphql-java-support/src/test/resources/schemas/nonResolvableKey/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/nonResolvableKey/schema_full.graphql
@@ -51,7 +51,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = User
 

--- a/graphql-java-support/src/test/resources/schemas/scalars/schema_federated.graphql
+++ b/graphql-java-support/src/test/resources/schemas/scalars/schema_federated.graphql
@@ -26,7 +26,7 @@ directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
 
 directive @shareable repeatable on OBJECT | FIELD_DEFINITION
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = DeprecatedProduct | Inventory | Product | ProductResearch | User
 

--- a/graphql-java-support/src/test/resources/schemas/scalars/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/scalars/schema_full.graphql
@@ -53,7 +53,7 @@ directive @specifiedBy(
     url: String!
   ) on SCALAR
 
-directive @tag(name: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 union _Entity = DeprecatedProduct | Inventory | Product | ProductResearch | User
 


### PR DESCRIPTION
Starting with Federation v2.3 `@tag` is applicable on `SCHEMA` as well.