### PR TITLE
Replace Discord with Discourse links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![MIT License](https://img.shields.io/github/license/apollographql/federation-jvm.svg)](LICENSE)
 [![Maven Central](https://img.shields.io/maven-central/v/com.apollographql.federation/federation-graphql-java-support.svg)](https://maven-badges.herokuapp.com/maven-central/com.apollographql.federation/federation-graphql-java-support)
 [![Join the community forum](https://img.shields.io/badge/join%20the%20community-forum-blueviolet)](https://community.apollographql.com)
-[![Join our Discord server](https://img.shields.io/discord/1022972389463687228.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square)](https://discord.gg/graphos)
 
 # Apollo Federation on the JVM
 


### PR DESCRIPTION
Replace Discord with Discourse links since the Discourse Community Forum there is becoming our focus.