### PR TITLE
downgrade protobuf dependency to v3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,8 @@ version = 3.0-SNAPSHOT
 # dependencies
 annotationsVersion = 24.1.0
 graphQLJavaVersion = 22.3
-protobufVersion = 4.27.1
+# generated proto v3 messages can be used with v3 and v4
+protobufVersion = 3.25.5
 slf4jVersion = 2.0.16
 springBootVersion = 3.3.6
 


### PR DESCRIPTION
We are using protobuf to generate `ftv1` tracing information. Protobuf v4 made a backwards incompatible change that prevents using those messages with v3 services. Since there are a lot of existing libraries (including `grpc-java`) that still depend on the v3 format and generated protobuf v3 message can be used for both v3 and v4 services we'll be reverting to v3 as well.

See: https://github.com/grpc/grpc-java/issues/11015#issuecomment-2560196695

Resolves: https://github.com/apollographql/federation-jvm/issues/421