### PR TITLE
Revert "feat: Support custom field sorter generated by ServiceSDLPrinter service SDL"

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -88,9 +88,7 @@ public final class Federation {
     final GraphQLSchema schema =
         new SchemaGenerator()
             .makeExecutableSchema(generatorOptions, typeRegistry, federatedRuntimeWiring);
-    return transform(schema, queryTypeShouldBeEmpty)
-      .setFederation2(importedDefinitions != null)
-      .setSchemaPrinterComparatorRegistry(federatedRuntimeWiring.getComparatorRegistry());
+    return transform(schema, queryTypeShouldBeEmpty).setFederation2(importedDefinitions != null);
   }
 
   public static SchemaTransformer transform(final TypeDefinitionRegistry typeRegistry) {

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/SchemaTransformer.java
@@ -20,14 +20,12 @@ import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
-import graphql.schema.GraphqlTypeComparatorRegistry;
 import graphql.schema.TypeResolver;
 import graphql.schema.idl.errors.SchemaProblem;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
@@ -41,7 +39,6 @@ public final class SchemaTransformer {
   private DataFetcherFactory entitiesDataFetcherFactory = null;
   private Coercing coercingForAny = _Any.type.getCoercing();
   private boolean isFederation2 = false;
-  private GraphqlTypeComparatorRegistry comparatorRegistry;
 
   SchemaTransformer(GraphQLSchema originalSchema, boolean queryTypeShouldBeEmpty) {
     this.originalSchema = originalSchema;
@@ -78,11 +75,6 @@ public final class SchemaTransformer {
     return this;
   }
 
-  public SchemaTransformer setSchemaPrinterComparatorRegistry(GraphqlTypeComparatorRegistry comparatorRegistry) {
-    this.comparatorRegistry = comparatorRegistry;
-    return this;
-  }
-
   @NotNull
   public GraphQLSchema build() throws SchemaProblem {
     // Make new Schema
@@ -115,10 +107,7 @@ public final class SchemaTransformer {
         (DataFetcher<Object>) environment -> serviceObject);
     final String sdl;
     if (isFederation2) {
-      GraphQLSchema generatingSource = newSchema.codeRegistry(newCodeRegistry.build( )).build( );
-      sdl = Optional.ofNullable(this.comparatorRegistry)
-        .map(customizer -> generateServiceSDLV2(generatingSource, customizer))
-        .orElse(generateServiceSDLV2(generatingSource));
+      sdl = generateServiceSDLV2(newSchema.codeRegistry(newCodeRegistry.build()).build());
     } else {
       // For Federation1, we filter out the federation definitions
       sdl = sdl(originalSchema, queryTypeShouldBeEmpty);

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/printer/ServiceSDLPrinter.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/printer/ServiceSDLPrinter.java
@@ -12,8 +12,6 @@ import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLNamedSchemaElement;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLSchemaElement;
-import graphql.schema.GraphqlTypeComparatorRegistry;
-import graphql.schema.DefaultGraphqlTypeComparatorRegistry;
 import graphql.schema.idl.DirectiveInfo;
 import graphql.schema.idl.SchemaPrinter;
 import graphql.schema.visibility.GraphqlFieldVisibility;
@@ -125,29 +123,17 @@ public final class ServiceSDLPrinter {
    * @return SDL compatible with Federation v2
    */
   public static String generateServiceSDLV2(GraphQLSchema schema) {
-    return generateServiceSDLV2(schema, DefaultGraphqlTypeComparatorRegistry.defaultComparators());
-  }
-
-  /**
-   * Generate service SDL compatible with Federation v2 specification.
-   *
-   * @param schema target schema
-   * @param comparatorRegistry custom schema element comparator for controlling print order
-   * @return SDL compatible with Federation v2
-   */
-  public static String generateServiceSDLV2(GraphQLSchema schema, GraphqlTypeComparatorRegistry comparatorRegistry) {
     // federation v2 SDL does not need to filter federation directive definitions
     final Predicate<GraphQLSchemaElement> excludeBuiltInDirectiveDefinitions =
-      element ->
-        !(element instanceof GraphQLDirective
-          && DirectiveInfo.isGraphqlSpecifiedDirective((GraphQLDirective) element));
+        element ->
+            !(element instanceof GraphQLDirective
+                && DirectiveInfo.isGraphqlSpecifiedDirective((GraphQLDirective) element));
     return new SchemaPrinter(
-      SchemaPrinter.Options.defaultOptions()
-        .includeSchemaDefinition(true)
-        .includeScalarTypes(true)
-        .includeSchemaElement(excludeBuiltInDirectiveDefinitions)
-        .setComparators(comparatorRegistry))
-      .print(schema)
-      .trim();
+            SchemaPrinter.Options.defaultOptions()
+                .includeSchemaDefinition(true)
+                .includeScalarTypes(true)
+                .includeSchemaElement(excludeBuiltInDirectiveDefinitions))
+        .print(schema)
+        .trim();
   }
 }


### PR DESCRIPTION
Unfortunately `RuntimeWiring` specifies different default comparator than the default one used by the `SchemaPrinter`.

Reverts apollographql/federation-jvm#445