### PR TITLE
Upgrade to graphql-java 25.0 and Spring Boot 4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group = com.apollographql.federation
 version = 3.0-SNAPSHOT
 
 # dependencies
-annotationsVersion = 24.1.0
+annotationsVersion = 26.0.1
 graphQLJavaVersion = 25.0
 # generated proto v3 messages can be used with v3 and v4
 protobufVersion = 3.25.5
@@ -10,10 +10,10 @@ slf4jVersion = 2.0.16
 springBootVersion = 4.0.2
 
 # test dependencies
-junitVersion = 5.10.5
+junitVersion = 5.11.4
 mockWebServerVersion = 4.12.0
 springGraphQLVersion = 2.0.2
-reactorVersion = 3.6.12
+reactorVersion = 3.7.4
 
 # plugin versions
-nexusPublishPluginVersion = 1.1.0
+nexusPublishPluginVersion = 2.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@ version = 3.0-SNAPSHOT
 
 # dependencies
 annotationsVersion = 24.1.0
-graphQLJavaVersion = 22.3
+graphQLJavaVersion = 25.0
 # generated proto v3 messages can be used with v3 and v4
 protobufVersion = 3.25.5
 slf4jVersion = 2.0.16
-springBootVersion = 3.3.6
+springBootVersion = 4.0.2
 
 # test dependencies
 junitVersion = 5.10.5
 mockWebServerVersion = 4.12.0
-springGraphQLVersion = 1.3.3
+springGraphQLVersion = 2.0.2
 reactorVersion = 3.6.12
 
 # plugin versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,3 @@ junitVersion = 5.11.4
 mockWebServerVersion = 4.12.0
 springGraphQLVersion = 2.0.2
 reactorVersion = 3.7.4
-
-# plugin versions
-nexusPublishPluginVersion = 2.0.0

--- a/graphql-java-support/src/test/resources/schemas/authorization/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/authorization/schema_full.graphql
@@ -4,11 +4,22 @@ schema @link(import : ["@authenticated", "@key", "@requiresScopes", "Scope", "Fi
 
 directive @authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 

--- a/graphql-java-support/src/test/resources/schemas/cacheTag/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/cacheTag/schema_full.graphql
@@ -4,11 +4,22 @@ schema @link(import : ["@key", "@cacheTag"], url : "https://specs.apollo.dev/fed
 
 directive @cacheTag(format: String!) repeatable on OBJECT | FIELD_DEFINITION
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 

--- a/graphql-java-support/src/test/resources/schemas/composeDirective/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/composeDirective/schema_full.graphql
@@ -4,11 +4,22 @@ schema @composeDirective(name : "@myDirective") @composeDirective(name : "@hello
 
 directive @composeDirective(name: String!) repeatable on SCHEMA
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/context/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/context/schema_full.graphql
@@ -4,11 +4,22 @@ schema @link(import : ["@key", "@context", "@fromContext"], url : "https://specs
 
 directive @context(name: String!) repeatable on OBJECT | INTERFACE | UNION
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 

--- a/graphql-java-support/src/test/resources/schemas/cost/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/cost/schema_full.graphql
@@ -4,11 +4,22 @@ schema @link(import : ["@cost", "@key", "@listSize"], url : "https://specs.apoll
 
 directive @cost(weight: Int!) on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM | INPUT_FIELD_DEFINITION
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 

--- a/graphql-java-support/src/test/resources/schemas/customAuthenticated/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/customAuthenticated/schema_full.graphql
@@ -4,11 +4,22 @@ schema @link(import : ["@key"], url : "https://specs.apollo.dev/federation/v2.5"
 
 directive @authenticated(role: [String!]!) on FIELD_DEFINITION
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 

--- a/graphql-java-support/src/test/resources/schemas/entitiesOnlySubgraph/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/entitiesOnlySubgraph/schema_full.graphql
@@ -2,11 +2,22 @@ schema {
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/extendSchema/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/extendSchema/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key"], url : "https://specs.apollo.dev/federation/v2.0"
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/fedV1/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/fedV1/schema_full.graphql
@@ -2,11 +2,22 @@ schema {
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/fedV2/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/fedV2/schema_full.graphql
@@ -6,11 +6,22 @@ directive @composeDirective(name: String!) repeatable on SCHEMA
 
 directive @custom on OBJECT
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/interfaceEntity/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceEntity/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key"], url : "https://specs.apollo.dev/federation/v2.3"
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 

--- a/graphql-java-support/src/test/resources/schemas/interfaceObject/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/interfaceObject/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key", "@interfaceObject"], url : "https://specs.apollo.
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 

--- a/graphql-java-support/src/test/resources/schemas/noEntities/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/noEntities/schema_full.graphql
@@ -2,11 +2,22 @@ schema {
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/nonResolvableKey/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/nonResolvableKey/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key"], url : "https://specs.apollo.dev/federation/v2.3"
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 

--- a/graphql-java-support/src/test/resources/schemas/policy/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/policy/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key", "@policy", "Policy", "FieldSet"], url : "https://
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENUM
 

--- a/graphql-java-support/src/test/resources/schemas/progressiveOverride/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/progressiveOverride/schema_full.graphql
@@ -6,11 +6,22 @@ directive @authenticated on SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | ENU
 
 directive @composeDirective(name: String!) repeatable on SCHEMA
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/renamedImports/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/renamedImports/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : [{name : "@key", as : "@myKey"}, {name : "@shareable"}, "@
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/repeatableShareable/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/repeatableShareable/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key", "@shareable"], url : "https://specs.apollo.dev/fe
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__composeDirective(name: String!) repeatable on SCHEMA
 

--- a/graphql-java-support/src/test/resources/schemas/scalars/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/scalars/schema_full.graphql
@@ -6,11 +6,22 @@ directive @composeDirective(name: String!) repeatable on SCHEMA
 
 directive @custom on OBJECT
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @extends on OBJECT | INTERFACE
 

--- a/graphql-java-support/src/test/resources/schemas/schemaImport/schema_full.graphql
+++ b/graphql-java-support/src/test/resources/schemas/schemaImport/schema_full.graphql
@@ -2,11 +2,22 @@ schema @link(import : ["@key"], url : "https://specs.apollo.dev/federation/v2.0"
   query: Query
 }
 
+"This directive allows results to be deferred during execution"
+directive @defer(
+    "Deferred behaviour is controlled by this argument"
+    if: Boolean! = true,
+    "A unique label that represents the fragment being deferred"
+    label: String
+  ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 "Marks the field, argument, input field or enum value as deprecated"
 directive @deprecated(
     "The reason for the deprecation"
-    reason: String = "No longer supported"
+    reason: String! = "No longer supported"
   ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
+
+"This directive disables error propagation when a non nullable field returns null for the given operation."
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 
 directive @federation__extends on OBJECT | INTERFACE
 

--- a/spring-subscription-callback/build.gradle.kts
+++ b/spring-subscription-callback/build.gradle.kts
@@ -24,9 +24,11 @@ dependencies {
     testImplementation(project(":federation-graphql-java-support"))
     testImplementation("com.squareup.okhttp3", "mockwebserver", mockWebServerVersion)
     testImplementation("org.springframework.boot", "spring-boot-starter-test", springBootVersion)
+    testImplementation("org.springframework.boot", "spring-boot-starter-webflux-test", springBootVersion)
     testImplementation("org.springframework.boot", "spring-boot-starter-websocket", springBootVersion)
     testImplementation("org.springframework.graphql", "spring-graphql-test", springGraphQLVersion)
     testImplementation("io.projectreactor", "reactor-test", reactorVersion)
+    testRuntimeOnly("org.junit.platform", "junit-platform-launcher")
 }
 
 java {

--- a/spring-subscription-callback/build.gradle.kts
+++ b/spring-subscription-callback/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testImplementation("org.springframework.boot", "spring-boot-starter-test", springBootVersion)
     testImplementation("org.springframework.boot", "spring-boot-starter-webflux-test", springBootVersion)
     testImplementation("org.springframework.boot", "spring-boot-starter-websocket", springBootVersion)
+    testImplementation("org.springframework.boot", "spring-boot-webclient-test", springBootVersion)
     testImplementation("org.springframework.graphql", "spring-graphql-test", springGraphQLVersion)
     testImplementation("io.projectreactor", "reactor-test", reactorVersion)
     testRuntimeOnly("org.junit.platform", "junit-platform-launcher")

--- a/spring-subscription-callback/src/main/java/com/apollographql/subscription/CallbackWebGraphQLInterceptor.java
+++ b/spring-subscription-callback/src/main/java/com/apollographql/subscription/CallbackWebGraphQLInterceptor.java
@@ -133,8 +133,8 @@ public class CallbackWebGraphQLInterceptor implements WebGraphQlInterceptor, Ord
       Map<String, List<String>> contextualHeaders = new HashMap<>();
       var headers = request.getHeaders();
       for (String header : this.contextualHeaders) {
-        if (headers.containsKey(header)) {
-          var headerValue = request.getHeaders().get(header);
+        var headerValue = headers.get(header);
+        if (headerValue != null && !headerValue.isEmpty()) {
           contextualHeaders.put(header, headerValue);
         }
       }

--- a/spring-subscription-callback/src/main/java/com/apollographql/subscription/CallbackWebGraphQLInterceptor.java
+++ b/spring-subscription-callback/src/main/java/com/apollographql/subscription/CallbackWebGraphQLInterceptor.java
@@ -133,8 +133,8 @@ public class CallbackWebGraphQLInterceptor implements WebGraphQlInterceptor, Ord
       Map<String, List<String>> contextualHeaders = new HashMap<>();
       var headers = request.getHeaders();
       for (String header : this.contextualHeaders) {
-        var headerValue = headers.get(header);
-        if (headerValue != null && !headerValue.isEmpty()) {
+        if (headers.containsHeader(header)) {
+          var headerValue = headers.get(header);
           contextualHeaders.put(header, headerValue);
         }
       }

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
@@ -8,7 +8,6 @@ import com.apollographql.subscription.exception.CallbackInitializationFailedExce
 import com.apollographql.subscription.message.CallbackMessageCheck;
 import com.apollographql.subscription.message.CallbackMessageComplete;
 import com.apollographql.subscription.message.CallbackMessageNext;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.ExecutionResult;
 import java.io.IOException;
 import java.net.URI;
@@ -38,6 +37,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import tools.jackson.databind.ObjectMapper;
 
 public class SubscriptionCallbackHandlerTest {
 

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
@@ -82,7 +82,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
 
       var graphQLRequest = stubWebGraphQLRequest(subscriptionId, callbackUrl);
@@ -139,7 +139,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
 
       var graphQLRequest = stubWebGraphQLRequest(subscriptionId, callbackUrl);
@@ -180,7 +180,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -245,7 +245,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -289,7 +289,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -318,7 +318,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 0);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -348,7 +348,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = callbackUrl;
+      var verifier = "junit";
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
@@ -82,7 +82,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
 
       var graphQLRequest = stubWebGraphQLRequest(subscriptionId, callbackUrl);
@@ -139,7 +139,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
 
       var graphQLRequest = stubWebGraphQLRequest(subscriptionId, callbackUrl);
@@ -180,7 +180,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -245,7 +245,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -289,7 +289,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -318,7 +318,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 0);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 
@@ -348,7 +348,7 @@ public class SubscriptionCallbackHandlerTest {
 
       var subscriptionId = UUID.randomUUID().toString();
       var callbackUrl = server.url("/callback/" + subscriptionId).toString();
-      var verifier = "junit";
+      var verifier = callbackUrl;
       var callback = new SubscriptionCallback(callbackUrl, subscriptionId, verifier, 5000);
       var client = WebClient.builder().baseUrl(callback.callback_url()).build();
 

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/callback/SubscriptionCallbackHandlerTest.java
@@ -102,16 +102,16 @@ public class SubscriptionCallbackHandlerTest {
       var objectMapper = new ObjectMapper();
       Assertions.assertEquals(4, capturedRequests.size());
       Assertions.assertEquals(
-          new CallbackMessageCheck(subscriptionId, callbackUrl),
+          new CallbackMessageCheck(subscriptionId, verifier),
           objectMapper.readValue(capturedRequests.get(0), CallbackMessageCheck.class));
       Assertions.assertEquals(
-          nextMessage(subscriptionId, callbackUrl, 1),
+          nextMessage(subscriptionId, verifier, 1),
           objectMapper.readValue(capturedRequests.get(1), CallbackMessageNext.class));
       Assertions.assertEquals(
-          nextMessage(subscriptionId, callbackUrl, 2),
+          nextMessage(subscriptionId, verifier, 2),
           objectMapper.readValue(capturedRequests.get(2), CallbackMessageNext.class));
       Assertions.assertEquals(
-          new CallbackMessageComplete(subscriptionId, callbackUrl),
+          new CallbackMessageComplete(subscriptionId, verifier),
           objectMapper.readValue(capturedRequests.get(3), CallbackMessageComplete.class));
     } catch (IOException | InterruptedException e) {
       // failed to close the server
@@ -155,7 +155,7 @@ public class SubscriptionCallbackHandlerTest {
       var objectMapper = new ObjectMapper();
       Assertions.assertEquals(1, capturedRequests.size());
       Assertions.assertEquals(
-          new CallbackMessageCheck(subscriptionId, callbackUrl),
+          new CallbackMessageCheck(subscriptionId, verifier),
           objectMapper.readValue(capturedRequests.get(0), CallbackMessageCheck.class));
     } catch (IOException | InterruptedException e) {
       // failed to close the server
@@ -203,16 +203,16 @@ public class SubscriptionCallbackHandlerTest {
       var objectMapper = new ObjectMapper();
       Assertions.assertEquals(4, capturedRequests.size());
       Assertions.assertEquals(
-          nextMessage(subscriptionId, callbackUrl, 1),
+          nextMessage(subscriptionId, verifier, 1),
           objectMapper.readValue(capturedRequests.get(0), CallbackMessageNext.class));
       Assertions.assertEquals(
-          new CallbackMessageCheck(subscriptionId, callbackUrl),
+          new CallbackMessageCheck(subscriptionId, verifier),
           objectMapper.readValue(capturedRequests.get(1), CallbackMessageCheck.class));
       Assertions.assertEquals(
-          nextMessage(subscriptionId, callbackUrl, 2),
+          nextMessage(subscriptionId, verifier, 2),
           objectMapper.readValue(capturedRequests.get(2), CallbackMessageNext.class));
       Assertions.assertEquals(
-          new CallbackMessageComplete(subscriptionId, callbackUrl),
+          new CallbackMessageComplete(subscriptionId, verifier),
           objectMapper.readValue(capturedRequests.get(3), CallbackMessageComplete.class));
     } catch (IOException e) {
       // failed to close the server
@@ -266,10 +266,10 @@ public class SubscriptionCallbackHandlerTest {
       var objectMapper = new ObjectMapper();
       Assertions.assertEquals(2, capturedRequests.size());
       Assertions.assertEquals(
-          nextMessage(subscriptionId, callbackUrl, 1),
+          nextMessage(subscriptionId, verifier, 1),
           objectMapper.readValue(capturedRequests.get(0), CallbackMessageNext.class));
       Assertions.assertEquals(
-          new CallbackMessageCheck(subscriptionId, callbackUrl),
+          new CallbackMessageCheck(subscriptionId, verifier),
           objectMapper.readValue(capturedRequests.get(1), CallbackMessageCheck.class));
     } catch (IOException e) {
       // failed to close the server

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/configuration/TestGraphQLConfiguration.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/configuration/TestGraphQLConfiguration.java
@@ -1,6 +1,6 @@
 package com.apollographql.subscription.configuration;
 
-import org.springframework.boot.autoconfigure.graphql.GraphQlSourceBuilderCustomizer;
+import org.springframework.boot.graphql.autoconfigure.GraphQlSourceBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.graphql.data.federation.FederationSchemaFactory;
 

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/webflux/CallbackGraphQLWebfluxHttpHandlerIT.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/webflux/CallbackGraphQLWebfluxHttpHandlerIT.java
@@ -6,7 +6,6 @@ import com.apollographql.subscription.callback.SubscriptionCallbackHandler;
 import com.apollographql.subscription.configuration.TestGraphQLConfiguration;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -45,12 +44,15 @@ public class CallbackGraphQLWebfluxHttpHandlerIT extends CallbackGraphQLHttpHand
     }
   }
 
-  @Autowired private WebTestClient testClient;
   @LocalServerPort private int serverPort;
+
+  private WebTestClient getTestClient() {
+    return WebTestClient.bindToServer().baseUrl("http://localhost:" + serverPort).build();
+  }
 
   @Test
   public void queries_works() {
-    verifyQueriesWorks(testClient);
+    verifyQueriesWorks(getTestClient());
   }
 
   @Test
@@ -61,26 +63,26 @@ public class CallbackGraphQLWebfluxHttpHandlerIT extends CallbackGraphQLHttpHand
 
   @Test
   public void callbackSubscription_works() {
-    verifySuccessfulCallbackSubscription(testClient);
+    verifySuccessfulCallbackSubscription(getTestClient());
   }
 
   @Test
   public void callbackSubscription_withHeaders_works() {
-    verifySuccessfulCallbackSubscriptionWithHeaders(testClient);
+    verifySuccessfulCallbackSubscriptionWithHeaders(getTestClient());
   }
 
   @Test
   public void postSubscription_withoutCallback_returns404() {
-    verifyPostSubscriptionsWithoutCallbackDontWork(testClient);
+    verifyPostSubscriptionsWithoutCallbackDontWork(getTestClient());
   }
 
   @Test
   public void callback_initFailed_returns404() {
-    verifyFailedCallbackInit(testClient);
+    verifyFailedCallbackInit(getTestClient());
   }
 
   @Test
   public void callback_malformedRequest_returns404() {
-    verifyMalformedCallbackInfo(testClient);
+    verifyMalformedCallbackInfo(getTestClient());
   }
 }

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/webflux/CallbackGraphQLWebfluxHttpHandlerIT.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/webflux/CallbackGraphQLWebfluxHttpHandlerIT.java
@@ -6,9 +6,11 @@ import com.apollographql.subscription.callback.SubscriptionCallbackHandler;
 import com.apollographql.subscription.configuration.TestGraphQLConfiguration;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +19,7 @@ import org.springframework.graphql.ExecutionGraphQlService;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 @EnableAutoConfiguration
+@AutoConfigureWebTestClient
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = CallbackGraphQLWebfluxHttpHandlerIT.GraphQLSubscriptionConfiguration.class,
@@ -44,15 +47,12 @@ public class CallbackGraphQLWebfluxHttpHandlerIT extends CallbackGraphQLHttpHand
     }
   }
 
+  @Autowired private WebTestClient testClient;
   @LocalServerPort private int serverPort;
-
-  private WebTestClient getTestClient() {
-    return WebTestClient.bindToServer().baseUrl("http://localhost:" + serverPort).build();
-  }
 
   @Test
   public void queries_works() {
-    verifyQueriesWorks(getTestClient());
+    verifyQueriesWorks(testClient);
   }
 
   @Test
@@ -63,26 +63,26 @@ public class CallbackGraphQLWebfluxHttpHandlerIT extends CallbackGraphQLHttpHand
 
   @Test
   public void callbackSubscription_works() {
-    verifySuccessfulCallbackSubscription(getTestClient());
+    verifySuccessfulCallbackSubscription(testClient);
   }
 
   @Test
   public void callbackSubscription_withHeaders_works() {
-    verifySuccessfulCallbackSubscriptionWithHeaders(getTestClient());
+    verifySuccessfulCallbackSubscriptionWithHeaders(testClient);
   }
 
   @Test
   public void postSubscription_withoutCallback_returns404() {
-    verifyPostSubscriptionsWithoutCallbackDontWork(getTestClient());
+    verifyPostSubscriptionsWithoutCallbackDontWork(testClient);
   }
 
   @Test
   public void callback_initFailed_returns404() {
-    verifyFailedCallbackInit(getTestClient());
+    verifyFailedCallbackInit(testClient);
   }
 
   @Test
   public void callback_malformedRequest_returns404() {
-    verifyMalformedCallbackInfo(getTestClient());
+    verifyMalformedCallbackInfo(testClient);
   }
 }

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/webmvc/CallbackGraphQLWebmvcHttpHandlerIT.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/webmvc/CallbackGraphQLWebmvcHttpHandlerIT.java
@@ -6,7 +6,6 @@ import com.apollographql.subscription.callback.SubscriptionCallbackHandler;
 import com.apollographql.subscription.configuration.TestGraphQLConfiguration;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -44,12 +43,15 @@ public class CallbackGraphQLWebmvcHttpHandlerIT extends CallbackGraphQLHttpHandl
     }
   }
 
-  @Autowired private WebTestClient testClient;
   @LocalServerPort private int serverPort;
+
+  private WebTestClient getTestClient() {
+    return WebTestClient.bindToServer().baseUrl("http://localhost:" + serverPort).build();
+  }
 
   @Test
   public void queries_works() {
-    verifyQueriesWorks(testClient);
+    verifyQueriesWorks(getTestClient());
   }
 
   @Test
@@ -60,26 +62,26 @@ public class CallbackGraphQLWebmvcHttpHandlerIT extends CallbackGraphQLHttpHandl
 
   @Test
   public void callbackSubscription_works() {
-    verifySuccessfulCallbackSubscription(testClient);
+    verifySuccessfulCallbackSubscription(getTestClient());
   }
 
   @Test
   public void callbackSubscription_withHeaders_works() {
-    verifySuccessfulCallbackSubscriptionWithHeaders(testClient);
+    verifySuccessfulCallbackSubscriptionWithHeaders(getTestClient());
   }
 
   @Test
   public void postSubscription_withoutCallback_returns404() {
-    verifyPostSubscriptionsWithoutCallbackDontWork(testClient);
+    verifyPostSubscriptionsWithoutCallbackDontWork(getTestClient());
   }
 
   @Test
   public void callback_initFailed_returns404() {
-    verifyFailedCallbackInit(testClient);
+    verifyFailedCallbackInit(getTestClient());
   }
 
   @Test
   public void callback_malformedRequest_returns404() {
-    verifyMalformedCallbackInfo(testClient);
+    verifyMalformedCallbackInfo(getTestClient());
   }
 }

--- a/spring-subscription-callback/src/test/java/com/apollographql/subscription/webmvc/CallbackGraphQLWebmvcHttpHandlerIT.java
+++ b/spring-subscription-callback/src/test/java/com/apollographql/subscription/webmvc/CallbackGraphQLWebmvcHttpHandlerIT.java
@@ -6,9 +6,11 @@ import com.apollographql.subscription.callback.SubscriptionCallbackHandler;
 import com.apollographql.subscription.configuration.TestGraphQLConfiguration;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +19,7 @@ import org.springframework.graphql.ExecutionGraphQlService;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 @EnableAutoConfiguration
+@AutoConfigureWebTestClient
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = CallbackGraphQLWebmvcHttpHandlerIT.GraphQLSubscriptionConfiguration.class,
@@ -43,15 +46,12 @@ public class CallbackGraphQLWebmvcHttpHandlerIT extends CallbackGraphQLHttpHandl
     }
   }
 
+  @Autowired private WebTestClient testClient;
   @LocalServerPort private int serverPort;
-
-  private WebTestClient getTestClient() {
-    return WebTestClient.bindToServer().baseUrl("http://localhost:" + serverPort).build();
-  }
 
   @Test
   public void queries_works() {
-    verifyQueriesWorks(getTestClient());
+    verifyQueriesWorks(testClient);
   }
 
   @Test
@@ -62,26 +62,26 @@ public class CallbackGraphQLWebmvcHttpHandlerIT extends CallbackGraphQLHttpHandl
 
   @Test
   public void callbackSubscription_works() {
-    verifySuccessfulCallbackSubscription(getTestClient());
+    verifySuccessfulCallbackSubscription(testClient);
   }
 
   @Test
   public void callbackSubscription_withHeaders_works() {
-    verifySuccessfulCallbackSubscriptionWithHeaders(getTestClient());
+    verifySuccessfulCallbackSubscriptionWithHeaders(testClient);
   }
 
   @Test
   public void postSubscription_withoutCallback_returns404() {
-    verifyPostSubscriptionsWithoutCallbackDontWork(getTestClient());
+    verifyPostSubscriptionsWithoutCallbackDontWork(testClient);
   }
 
   @Test
   public void callback_initFailed_returns404() {
-    verifyFailedCallbackInit(getTestClient());
+    verifyFailedCallbackInit(testClient);
   }
 
   @Test
   public void callback_malformedRequest_returns404() {
-    verifyMalformedCallbackInfo(getTestClient());
+    verifyMalformedCallbackInfo(testClient);
   }
 }


### PR DESCRIPTION
This PR upgrades the project to graphql-java to 25.0 and Spring Boot 4.0.2 and updates all dependencies to their latest compatible stable versions.

### Major Version Updates
- **Spring Boot**: 3.3.6 → 4.0.2
- **Spring GraphQL**: 1.3.3 → 2.0.2
- **graphql-java**: 22.3 → 25.0

### Dependency Updates
- **JetBrains Annotations**: 24.1.0 → 26.0.1
- **JUnit**: 5.10.5 → 5.11.4
- **Reactor**: 3.6.12 → 3.7.4
- **Nexus Publish Plugin**: Removed

### Breaking Changes Fixed
- Updated test schema snapshots for graphql-java 25 SDL output format changes
- Updated package imports for Spring Boot 4 (`GraphQlSourceBuilderCustomizer`, `ObjectMapper`)
- Fixed Jackson 3.x namespace change (`com.fasterxml` → `tools.jackson`)
- ~Resolved Spring Boot 4 test infrastructure changes (removed auto-wired `WebTestClient`, created local factory methods)~
- Fixed subscription callback tests to use `verifier`, not callback URL.

### Test Results
- ✅ All 106 tests passing
- ✅ Spotless formatting verified
- ✅ Code coverage requirements met
- ✅ Full build successful

### Reviewer Note

Claude performed the heavy lifting. I'm not so familiar with this codebase and certainly not sure if the spring-subscription-callback test updates make sense. Please review the tests thoroughly.