### PR TITLE
feat: add Federation v2.13 and v2.14 support

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/Federation.java
@@ -39,6 +39,8 @@ public final class Federation {
   public static final String FEDERATION_SPEC_V2_10 = "https://specs.apollo.dev/federation/v2.10";
   public static final String FEDERATION_SPEC_V2_11 = "https://specs.apollo.dev/federation/v2.11";
   public static final String FEDERATION_SPEC_V2_12 = "https://specs.apollo.dev/federation/v2.12";
+  public static final String FEDERATION_SPEC_V2_13 = "https://specs.apollo.dev/federation/v2.13";
+  public static final String FEDERATION_SPEC_V2_14 = "https://specs.apollo.dev/federation/v2.14";
 
   private static final SchemaGenerator.Options defaultGeneratorOptions =
       SchemaGenerator.Options.defaultOptions();

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/FederationDirectives.java
@@ -5,6 +5,8 @@ import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPE
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_10;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_11;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_12;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_13;
+import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_14;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_2;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_3;
 import static com.apollographql.federation.graphqljava.Federation.FEDERATION_SPEC_V2_4;
@@ -242,6 +244,8 @@ public final class FederationDirectives {
       case FEDERATION_SPEC_V2_11:
         return loadFed2Definitions("definitions_fed2_9.graphqls");
       case FEDERATION_SPEC_V2_12:
+      case FEDERATION_SPEC_V2_13:
+      case FEDERATION_SPEC_V2_14:
         return loadFed2Definitions("definitions_fed2_12.graphqls");
       default:
         throw new UnsupportedFederationVersionException(federationSpec);

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/FederationTest.java
@@ -396,6 +396,40 @@ class FederationTest {
     verifyFederationTransformation("schemas/cacheTag/schema.graphql");
   }
 
+  @Test
+  public void verifyFederationV2Transformation_v213_isSupported() {
+    // Federation v2.13 introduces no new subgraph directives (Connect spec v0.4 prerequisite only),
+    // so any schema linking to v2.13 should resolve the same directive set as v2.12.
+    final String schemaSDL =
+        "extend schema @link(url: \"https://specs.apollo.dev/federation/v2.13\","
+            + " import: [\"@key\"])\n"
+            + "type Product @key(fields: \"id\") { id: ID! }\n"
+            + "type Query { product(id: ID!): Product }\n";
+    assertDoesNotThrow(
+        () ->
+            Federation.transform(schemaSDL)
+                .resolveEntityType(env -> null)
+                .fetchEntities(env -> null)
+                .build());
+  }
+
+  @Test
+  public void verifyFederationV2Transformation_v214_isSupported() {
+    // Federation v2.14 introduces no new subgraph directives (composition-only changes), so any
+    // schema linking to v2.14 should resolve the same directive set as v2.12.
+    final String schemaSDL =
+        "extend schema @link(url: \"https://specs.apollo.dev/federation/v2.14\","
+            + " import: [\"@key\"])\n"
+            + "type Product @key(fields: \"id\") { id: ID! }\n"
+            + "type Query { product(id: ID!): Product }\n";
+    assertDoesNotThrow(
+        () ->
+            Federation.transform(schemaSDL)
+                .resolveEntityType(env -> null)
+                .fetchEntities(env -> null)
+                .build());
+  }
+
   private void verifyFederationTransformation(String schemaFileName) {
     final RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring().build();
     verifyFederationTransformation(schemaFileName, runtimeWiring);


### PR DESCRIPTION
Adds Federation v2.13 and v2.14 support to the graphql-java subgraph library.
