### PR TITLE
fix: use `getAppliedDirective` in `CacheControlInstrumentation`

### DIFF
--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
@@ -308,6 +308,7 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
               .map(GraphQLAppliedDirectiveArgument::getValue)
               .filter(v -> v instanceof Integer)
               .map(Integer.class::cast)
+              .filter(v -> v >= 0)
               .orElse(null);
 
       CacheControlScope scope =
@@ -372,10 +373,6 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
     }
   }
 
-  private static class CacheControlHolder {
-    volatile String value;
-  }
-
   static List<GraphQLType> typesFromEntitiesArgument(Object representations, GraphQLSchema schema) {
     if (representations instanceof List) {
       return ((List<?>) representations)
@@ -390,4 +387,8 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
     }
     return new ArrayList<>();
   }
+}
+
+class CacheControlHolder {
+  volatile String value;
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
@@ -37,7 +37,6 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
   private final boolean allowZeroMaxAge;
 
   private static final Object CONTEXT_KEY = new Object();
-  private static final Object HOLDER_KEY = new Object();
   private static final String DIRECTIVE_NAME = "cacheControl";
   private static final String MAX_AGE = "maxAge";
   private static final String SCOPE = "scope";
@@ -56,25 +55,8 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
     this.allowZeroMaxAge = allowZeroMaxAge;
   }
 
-  /**
-   * Pre-installs a mutable result holder into the given context. Call this on the context
-   * <em>before</em> it is passed to graphql-java execution, if your framework copies the context
-   * when building an {@link graphql.ExecutionInput} (e.g. graphql-kotlin). Both the original
-   * context and the copy will share the same holder object by reference, so {@link
-   * #cacheControlHeaderFromGraphQLContext} can be called on either after execution.
-   *
-   * <p>If this method is not called, the instrumentation falls back to writing the result directly
-   * to the execution context, which is the correct behavior when the caller passes the exact same
-   * {@link GraphQLContext} instance to {@link graphql.ExecutionInput.Builder#graphQLContext}.
-   */
-  public static void prepareContext(GraphQLContext context) {
-    context.put(HOLDER_KEY, new CacheControlHolder());
-  }
-
   @Nullable
   public static String cacheControlHeaderFromGraphQLContext(GraphQLContext context) {
-    CacheControlHolder holder = context.get(HOLDER_KEY);
-    if (holder != null) return holder.value;
     return context.get(CONTEXT_KEY);
   }
 
@@ -101,16 +83,7 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
         cacheControlState
             .overallPolicy
             .maybeAsString()
-            .ifPresent(
-                s -> {
-                  GraphQLContext ctx = parameters.getGraphQLContext();
-                  CacheControlHolder holder = ctx.get(HOLDER_KEY);
-                  if (holder != null) {
-                    holder.value = s;
-                  } else {
-                    ctx.put(CONTEXT_KEY, s);
-                  }
-                });
+            .ifPresent(s -> parameters.getGraphQLContext().put(CONTEXT_KEY, s));
       }
     };
   }
@@ -308,7 +281,6 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
               .map(GraphQLAppliedDirectiveArgument::getValue)
               .filter(v -> v instanceof Integer)
               .map(Integer.class::cast)
-              .filter(v -> v >= 0)
               .orElse(null);
 
       CacheControlScope scope =
@@ -387,8 +359,4 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
     }
     return new ArrayList<>();
   }
-}
-
-class CacheControlHolder {
-  volatile String value;
 }

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
@@ -37,6 +37,7 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
   private final boolean allowZeroMaxAge;
 
   private static final Object CONTEXT_KEY = new Object();
+  private static final Object HOLDER_KEY = new Object();
   private static final String DIRECTIVE_NAME = "cacheControl";
   private static final String MAX_AGE = "maxAge";
   private static final String SCOPE = "scope";
@@ -55,8 +56,25 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
     this.allowZeroMaxAge = allowZeroMaxAge;
   }
 
+  /**
+   * Pre-installs a mutable result holder into the given context. Call this on the context
+   * <em>before</em> it is passed to graphql-java execution, if your framework copies the context
+   * when building an {@link graphql.ExecutionInput} (e.g. graphql-kotlin). Both the original
+   * context and the copy will share the same holder object by reference, so
+   * {@link #cacheControlHeaderFromGraphQLContext} can be called on either after execution.
+   *
+   * <p>If this method is not called, the instrumentation falls back to writing the result directly
+   * to the execution context, which is the correct behavior when the caller passes the exact same
+   * {@link GraphQLContext} instance to {@link graphql.ExecutionInput.Builder#graphQLContext}.
+   */
+  public static void prepareContext(GraphQLContext context) {
+    context.put(HOLDER_KEY, new CacheControlHolder());
+  }
+
   @Nullable
   public static String cacheControlHeaderFromGraphQLContext(GraphQLContext context) {
+    CacheControlHolder holder = context.get(HOLDER_KEY);
+    if (holder != null) return holder.value;
     return context.get(CONTEXT_KEY);
   }
 
@@ -83,7 +101,16 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
         cacheControlState
             .overallPolicy
             .maybeAsString()
-            .ifPresent(s -> parameters.getGraphQLContext().put(CONTEXT_KEY, s));
+            .ifPresent(
+                s -> {
+                  GraphQLContext ctx = parameters.getGraphQLContext();
+                  CacheControlHolder holder = ctx.get(HOLDER_KEY);
+                  if (holder != null) {
+                    holder.value = s;
+                  } else {
+                    ctx.put(CONTEXT_KEY, s);
+                  }
+                });
       }
     };
   }
@@ -270,7 +297,7 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
 
     public static Optional<CacheControlDirective> fromDirectiveContainer(
         GraphQLDirectiveContainer container) {
-      GraphQLDirective directive = container.getDirective(DIRECTIVE_NAME);
+      GraphQLAppliedDirective directive = container.getAppliedDirective(DIRECTIVE_NAME);
 
       if (directive == null) {
         return Optional.empty();
@@ -278,21 +305,21 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
 
       Integer maxAge =
           Optional.ofNullable(directive.getArgument(MAX_AGE))
-              .map(a -> GraphQLArgument.getArgumentValue(a))
+              .map(GraphQLAppliedDirectiveArgument::getValue)
               .filter(v -> v instanceof Integer)
               .map(Integer.class::cast)
               .orElse(null);
 
       CacheControlScope scope =
           Optional.ofNullable(directive.getArgument(SCOPE))
-              .map(a -> GraphQLArgument.getArgumentValue(a))
+              .map(GraphQLAppliedDirectiveArgument::getValue)
               .filter(v -> v instanceof String)
               .map(s -> CacheControlScope.valueOf((String) s))
               .orElse(null);
 
       Boolean inheritMaxAge =
           Optional.ofNullable(directive.getArgument(INHERIT_MAX_AGE))
-              .map(a -> GraphQLArgument.getArgumentValue(a))
+              .map(GraphQLAppliedDirectiveArgument::getValue)
               .filter(v -> v instanceof Boolean)
               .map(Boolean.class::cast)
               .orElse(null);
@@ -343,6 +370,10 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
       return String.format(
           "@cacheControl(maxAge: %s, scope: %s, inheritMaxAge: %s)", maxAge, scope, inheritMaxAge);
     }
+  }
+
+  private static class CacheControlHolder {
+    volatile String value;
   }
 
   static List<GraphQLType> typesFromEntitiesArgument(Object representations, GraphQLSchema schema) {

--- a/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
+++ b/graphql-java-support/src/main/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentation.java
@@ -60,8 +60,8 @@ public class CacheControlInstrumentation extends SimplePerformantInstrumentation
    * Pre-installs a mutable result holder into the given context. Call this on the context
    * <em>before</em> it is passed to graphql-java execution, if your framework copies the context
    * when building an {@link graphql.ExecutionInput} (e.g. graphql-kotlin). Both the original
-   * context and the copy will share the same holder object by reference, so
-   * {@link #cacheControlHeaderFromGraphQLContext} can be called on either after execution.
+   * context and the copy will share the same holder object by reference, so {@link
+   * #cacheControlHeaderFromGraphQLContext} can be called on either after execution.
    *
    * <p>If this method is not called, the instrumentation falls back to writing the result directly
    * to the execution context, which is the correct behavior when the caller passes the exact same

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
@@ -471,44 +471,6 @@ public class CacheControlInstrumentationTest {
             input.getGraphQLContext()));
   }
 
-  /**
-   * Simulates frameworks (e.g. graphql-kotlin) that copy the GraphQLContext when building an
-   * ExecutionInput. Without {@link CacheControlInstrumentation#prepareContext}, the header is
-   * written to the execution-context copy and the caller's original context stays empty. With
-   * {@code prepareContext}, both contexts share the same holder by reference.
-   */
-  @Test
-  void prepareContextSurvivesContextCopy() {
-    String schema =
-        "type Query {"
-            + "  droid(id: ID!): Droid @cacheControl(maxAge: 60)"
-            + "}"
-            + "type Droid {"
-            + "  id: ID!"
-            + "  name: String"
-            + "}";
-
-    GraphQL graphql = makeExecutor(schema, 0, false);
-
-    // Simulate graphql-kotlin's toExecutionInput which copies the context into a new object.
-    GraphQLContext originalContext = GraphQLContext.newContext().build();
-    CacheControlInstrumentation.prepareContext(originalContext);
-    GraphQLContext copiedContext = GraphQLContext.newContext().of(originalContext).build();
-
-    ExecutionInput input =
-        ExecutionInput.newExecutionInput()
-            .query("{ droid(id: 1) { name } }")
-            .graphQLContext(builder -> builder.of(copiedContext))
-            .build();
-
-    graphql.execute(input);
-
-    // The header must be readable from the original context, not just from the execution copy.
-    assertEquals(
-        "max-age=60, public",
-        CacheControlInstrumentation.cacheControlHeaderFromGraphQLContext(originalContext));
-  }
-
   @Test
   void entities() {
     String schema =

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
@@ -9,6 +9,11 @@ import graphql.ExecutionInput;
 import graphql.GraphQL;
 import graphql.GraphQLContext;
 import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLAppliedDirectiveArgument;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -402,6 +407,108 @@ public class CacheControlInstrumentationTest {
     assertNull(execute(schema, "{foo{defaultBar{cachedScalar}}}"));
     assertEquals("max-age=5, public", execute(schema, "{foo{bar{scalar}}}"));
     assertEquals("max-age=2, public", execute(schema, "{foo{bar{cachedScalar}}}"));
+  }
+
+  /**
+   * Verifies that @cacheControl directives applied programmatically via the graphql-java builder
+   * API are correctly read using {@code getAppliedDirective()}.
+   */
+  @Test
+  void hintOnFieldProgrammaticSchema() {
+    GraphQLDirective cacheControlDef =
+        GraphQLDirective.newDirective()
+            .name("cacheControl")
+            .argument(GraphQLArgument.newArgument().name("maxAge").type(graphql.Scalars.GraphQLInt))
+            .validLocations(
+                graphql.introspection.Introspection.DirectiveLocation.FIELD_DEFINITION,
+                graphql.introspection.Introspection.DirectiveLocation.OBJECT)
+            .build();
+
+    GraphQLAppliedDirective cacheControlApplied =
+        GraphQLAppliedDirective.newDirective()
+            .name("cacheControl")
+            .argument(
+                GraphQLAppliedDirectiveArgument.newArgument()
+                    .name("maxAge")
+                    .type(graphql.Scalars.GraphQLInt)
+                    .valueProgrammatic(60)
+                    .build())
+            .build();
+
+    GraphQLObjectType droidType =
+        GraphQLObjectType.newObject()
+            .name("Droid")
+            .field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name("name")
+                    .type(graphql.Scalars.GraphQLString))
+            .build();
+
+    GraphQLObjectType queryType =
+        GraphQLObjectType.newObject()
+            .name("Query")
+            .field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name("droid")
+                    .type(droidType)
+                    .withAppliedDirective(cacheControlApplied))
+            .build();
+
+    GraphQLSchema schema =
+        GraphQLSchema.newSchema()
+            .query(queryType)
+            .additionalDirective(cacheControlDef)
+            .build();
+
+    GraphQL graphql =
+        GraphQL.newGraphQL(schema)
+            .instrumentation(new CacheControlInstrumentation(0, false))
+            .build();
+
+    ExecutionInput input = ExecutionInput.newExecutionInput().query("{ droid { name } }").build();
+    graphql.execute(input);
+
+    assertEquals(
+        "max-age=60, public",
+        CacheControlInstrumentation.cacheControlHeaderFromGraphQLContext(input.getGraphQLContext()));
+  }
+
+  /**
+   * Simulates frameworks (e.g. graphql-kotlin) that copy the GraphQLContext when building an
+   * ExecutionInput. Without {@link CacheControlInstrumentation#prepareContext}, the header is
+   * written to the execution-context copy and the caller's original context stays empty. With
+   * {@code prepareContext}, both contexts share the same holder by reference.
+   */
+  @Test
+  void prepareContextSurvivesContextCopy() {
+    String schema =
+        "type Query {"
+            + "  droid(id: ID!): Droid @cacheControl(maxAge: 60)"
+            + "}"
+            + "type Droid {"
+            + "  id: ID!"
+            + "  name: String"
+            + "}";
+
+    GraphQL graphql = makeExecutor(schema, 0, false);
+
+    // Simulate graphql-kotlin's toExecutionInput which copies the context into a new object.
+    GraphQLContext originalContext = GraphQLContext.newContext().build();
+    CacheControlInstrumentation.prepareContext(originalContext);
+    GraphQLContext copiedContext = GraphQLContext.newContext().of(originalContext).build();
+
+    ExecutionInput input =
+        ExecutionInput.newExecutionInput()
+            .query("{ droid(id: 1) { name } }")
+            .graphQLContext(builder -> builder.of(copiedContext))
+            .build();
+
+    graphql.execute(input);
+
+    // The header must be readable from the original context, not just from the execution copy.
+    assertEquals(
+        "max-age=60, public",
+        CacheControlInstrumentation.cacheControlHeaderFromGraphQLContext(originalContext));
   }
 
   @Test

--- a/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
+++ b/graphql-java-support/src/test/java/com/apollographql/federation/graphqljava/caching/CacheControlInstrumentationTest.java
@@ -455,10 +455,7 @@ public class CacheControlInstrumentationTest {
             .build();
 
     GraphQLSchema schema =
-        GraphQLSchema.newSchema()
-            .query(queryType)
-            .additionalDirective(cacheControlDef)
-            .build();
+        GraphQLSchema.newSchema().query(queryType).additionalDirective(cacheControlDef).build();
 
     GraphQL graphql =
         GraphQL.newGraphQL(schema)
@@ -470,7 +467,8 @@ public class CacheControlInstrumentationTest {
 
     assertEquals(
         "max-age=60, public",
-        CacheControlInstrumentation.cacheControlHeaderFromGraphQLContext(input.getGraphQLContext()));
+        CacheControlInstrumentation.cacheControlHeaderFromGraphQLContext(
+            input.getGraphQLContext()));
   }
 
   /**


### PR DESCRIPTION
Updates `CacheControlInstrumentation` to use `getAppliedDirective` instead of deprecated `getDirective`.